### PR TITLE
HCS-2753 Apply fixes from UI template sanity testing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,5 +9,8 @@ hashicups_version:
 module_version:
 	scripts/module_version.sh
 
+toggle_dev:
+	scripts/toggle_dev.sh
+
 go/test:
 	cd test && go test ./hcp

--- a/examples/hcp-vm-demo/README.md
+++ b/examples/hcp-vm-demo/README.md
@@ -19,6 +19,14 @@ az login
 az account set --subscription="SUBSCRIPTION_ID"
 ```
 
+3. Create RSA keys if you don't already have them. Used for [SSH access to the Azure VMs](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/linux_virtual_machine).
+
+```
+if [ ! -f ~/.ssh/id_rsa.pub ]; then
+    ssh-keygen -t rsa -b 4096 -f ~/.ssh/id_rsa
+fi
+```
+
 ### Deployment
 
 1. Initialize and apply the Terraform configuration

--- a/examples/hcp-vm-demo/README.md
+++ b/examples/hcp-vm-demo/README.md
@@ -1,7 +1,6 @@
 # hcp-vm-demo
 
-This example creates all of the Azure and HCP resources necessary for connecting a
-HCP Consul cluster to a Consul client on Azure VM.
+This example creates all of the Azure and HCP resources necessary for connecting a HCP Consul cluster to a Consul client on Azure VM.
 
 ### Prerequisites
 
@@ -18,6 +17,8 @@ export HCP_CLIENT_SECRET=...
 az login
 az account set --subscription="SUBSCRIPTION_ID"
 ```
+
+The user must be assigned a [role granting authorization to create Service Principals](https://docs.microsoft.com/en-us/graph/api/serviceprincipal-post-serviceprincipals?view=graph-rest-1.0&tabs=http#permissions). For example: `Cloud Application Administrator` or `Application Administrator`.
 
 3. Create RSA keys if you don't already have them. Used for [SSH access to the Azure VMs](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/linux_virtual_machine).
 
@@ -48,7 +49,6 @@ This example is running on nomad, which can be accessed via the outputs `nomad_u
 
 #### VM instances
 
-**Warning**: This instance, by default, is publicly accessible on port 8080 and 8081,
-make sure to delete it when done.
+**Warning**: This instance, by default, is publicly accessible on port 8080 and 8081, make sure to delete it when done.
 
 The Azure VM applications be accessed via the `hashicups_url` output, providing URL to the demo app.

--- a/examples/hcp-vm-demo/main.tf
+++ b/examples/hcp-vm-demo/main.tf
@@ -53,10 +53,10 @@ module "hcp_peering" {
   vnet_rg         = azurerm_resource_group.rg.name
   vnet_id         = module.network.vnet_id
   subnet_ids      = module.network.vnet_subnets
-  prefix          = var.cluster_id
 
   # Optional
   security_group_names = [azurerm_network_security_group.nsg.name]
+  prefix               = var.cluster_id
 }
 
 resource "hcp_consul_cluster" "main" {

--- a/hcp-ui-templates/vm-existing-vnet/main.tf
+++ b/hcp-ui-templates/vm-existing-vnet/main.tf
@@ -73,10 +73,10 @@ module "hcp_peering" {
   vnet_rg         = data.azurerm_resource_group.rg.name
   vnet_id         = local.vnet_id
   subnet_ids      = [local.subnet_id]
-  prefix          = local.cluster_id
 
   # Optional
   security_group_names = [azurerm_network_security_group.nsg.name]
+  prefix               = local.cluster_id
 }
 
 resource "hcp_consul_cluster" "main" {

--- a/hcp-ui-templates/vm/main.tf
+++ b/hcp-ui-templates/vm/main.tf
@@ -98,10 +98,10 @@ module "hcp_peering" {
   vnet_rg         = azurerm_resource_group.rg.name
   vnet_id         = module.network.vnet_id
   subnet_ids      = module.network.vnet_subnets
-  prefix          = local.cluster_id
 
   # Optional
   security_group_names = [azurerm_network_security_group.nsg.name]
+  prefix               = local.cluster_id
 }
 
 resource "hcp_consul_cluster" "main" {

--- a/hcp-ui-templates/vm/main.tf
+++ b/hcp-ui-templates/vm/main.tf
@@ -3,7 +3,7 @@ locals {
   hvn_id         = "{{ .ClusterID }}-hvn"
   cluster_id     = "{{ .ClusterID }}"
   network_region = "{{ .VnetRegion }}"
-  vnet_cidr      = ["10.0.0.0/16"]
+  vnet_cidrs     = ["10.0.0.0/16"]
   vnet_subnets = {
     "subnet1" = "10.0.1.0/24",
   }

--- a/main.tf
+++ b/main.tf
@@ -126,7 +126,7 @@ data "hcp_azure_peering_connection" "peering" {
 resource "hcp_hvn_route" "route" {
   count        = length(data.azurerm_subnet.selected)
   hvn_link     = var.hvn.self_link
-  hvn_route_id = "${var.prefix}-${data.azurerm_subnet.selected[count.index].name}"
+  hvn_route_id = "${var.prefix}-${count.index}"
   # TODO: handle multiple cidrs attached to a single subnet. Taking first for now
   destination_cidr = data.azurerm_subnet.selected[count.index].address_prefixes[0]
   target_link      = data.hcp_azure_peering_connection.peering.self_link

--- a/main.tf
+++ b/main.tf
@@ -83,7 +83,7 @@ data "azurerm_subnet" "selected" {
 
 resource "hcp_azure_peering_connection" "peering" {
   hvn_link                 = var.hvn.self_link
-  peering_id               = "${var.prefix}-peering-id"
+  peering_id               = "${var.prefix}-peer"
   peer_vnet_name           = data.azurerm_virtual_network.vnet.name
   peer_subscription_id     = var.subscription_id
   peer_tenant_id           = var.tenant_id

--- a/scripts/snips/locals_new_vnet.snip
+++ b/scripts/snips/locals_new_vnet.snip
@@ -1,5 +1,5 @@
   network_region = "{{ .VnetRegion }}"
-  vnet_cidr  = ["10.0.0.0/16"]
+  vnet_cidrs  = ["10.0.0.0/16"]
   vnet_subnets = {
     "subnet1" = "10.0.1.0/24",
   }

--- a/scripts/toggle_dev.sh
+++ b/scripts/toggle_dev.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+
+file () {
+  echo "examples/hcp-$1-demo/main.tf"
+}
+
+dev () {
+  platform=$1
+  perl -i -pe "BEGIN{undef \$/;} s/hashicorp\/hcp-consul\/azurerm\/\/modules\/hcp-$platform-client\"\r?\n  /..\/..\/modules\/hcp-$platform-client\"\n  # /smg" $(file $1)
+}
+
+prod () {
+  platform=$1
+  perl -i -pe "s/# version/version/smg" $(file $1)
+  perl -i -pe "s/\.\.\/\.\.\/modules\/hcp-$platform-client/hashicorp\/hcp-consul\/azurerm\/\/modules\/hcp-$platform-client/smg" $(file $1)
+}
+
+isDev () {
+  grep -q "# version" $(file $1)
+  echo $?
+}
+
+dev=$(isDev "vm")
+for platform in vm; do
+  if [ $dev -eq 0 ]; then
+    prod $platform
+  else
+    dev $platform
+  fi
+done

--- a/test/hcp/testdata/vm-existing-vnet.golden
+++ b/test/hcp/testdata/vm-existing-vnet.golden
@@ -73,10 +73,10 @@ module "hcp_peering" {
   vnet_rg         = data.azurerm_resource_group.rg.name
   vnet_id         = local.vnet_id
   subnet_ids      = [local.subnet_id]
-  prefix          = local.cluster_id
 
   # Optional
   security_group_names = [azurerm_network_security_group.nsg.name]
+  prefix               = local.cluster_id
 }
 
 resource "hcp_consul_cluster" "main" {

--- a/test/hcp/testdata/vm.golden
+++ b/test/hcp/testdata/vm.golden
@@ -3,7 +3,7 @@ locals {
   hvn_id         = "consul-quickstart-1634271483588-hvn"
   cluster_id     = "consul-quickstart-1634271483588"
   network_region = "westus2"
-  vnet_cidr      = ["10.0.0.0/16"]
+  vnet_cidrs     = ["10.0.0.0/16"]
   vnet_subnets = {
     "subnet1" = "10.0.1.0/24",
   }

--- a/test/hcp/testdata/vm.golden
+++ b/test/hcp/testdata/vm.golden
@@ -98,10 +98,10 @@ module "hcp_peering" {
   vnet_rg         = azurerm_resource_group.rg.name
   vnet_id         = module.network.vnet_id
   subnet_ids      = module.network.vnet_subnets
-  prefix          = local.cluster_id
 
   # Optional
   security_group_names = [azurerm_network_security_group.nsg.name]
+  prefix               = local.cluster_id
 }
 
 resource "hcp_consul_cluster" "main" {


### PR DESCRIPTION
### Changes

- fix `vnet_cidr` -> `vnet_cidrs`
- fix to shorten peering ID and HVN ID (they both need to be <= 36 char total with the `consul-quickstart-$timestamp` prefix)
  - this change will require a `0.1.1` patch/release
- add toggle_dev script

### Testing

TF applied `vm.golden`. Fixed issues as they arose.

```
make
mkdir /tmp/azure-vm-golden-test
cp ./test/hcp/testdata/vm.golden /tmp/azure-vm-golden-test
cd /tmp/azure-vm-golden-test
mv vm.golden main.tf
tf init && tf apply
```

With the fixes here, I can create all the resources except for the HVN peering which waits + breaks for lack of AuthZ to create a SP:

```
│ Error: Could not create service principal
│ 
│   with module.hcp_peering.azuread_service_principal.principal,
│   on .terraform/modules/hcp_peering/main.tf line 94, in resource "azuread_service_principal" "principal":
│   94: resource "azuread_service_principal" "principal" {
  
│ ServicePrincipalsClient.BaseClient.Post(): unexpected status 403 with OData error: Authorization_RequestDenied: When using this permission, the
│ backing application of the service principal being created must in the local tenant
```

I am waiting on a HelpDesk request to get an Azure Admin role granted to complete the creation + sanity testing. I also added a note about the Azure user needing the above to the prereqs section: https://github.com/hashicorp/terraform-provider-azuread/blob/8bb1a9cfbd5dea247306d696effe2a49f9c7f31a/docs/guides/service_principal_configuration.md#method-2-directory-roles-recommended-for-users-ie-azure-cli-authentication