### PR TITLE
HCS-3137: Use one-off TLS private key for Azure VM

### DIFF
--- a/examples/hcp-vm-demo/README.md
+++ b/examples/hcp-vm-demo/README.md
@@ -20,14 +20,6 @@ az account set --subscription="SUBSCRIPTION_ID"
 
 The user must be assigned a [role granting authorization to create Service Principals](https://docs.microsoft.com/en-us/graph/api/serviceprincipal-post-serviceprincipals?view=graph-rest-1.0&tabs=http#permissions). For example: `Cloud Application Administrator` or `Application Administrator`.
 
-3. Create RSA keys if you don't already have them. Used for [SSH access to the Azure VMs](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/linux_virtual_machine).
-
-```
-if [ ! -f ~/.ssh/id_rsa.pub ]; then
-    ssh-keygen -t rsa -b 4096 -f ~/.ssh/id_rsa
-fi
-```
-
 ### Deployment
 
 1. Initialize and apply the Terraform configuration
@@ -38,10 +30,15 @@ terraform init && terraform apply
 
 ### Accessing the Deployment
 
+**Warning**: This instance, by default, is publicly accessible on port 8080 and 8081, make sure to delete it when done.
+
+#### HashiCups
+
+The web app is accessible at the `hashicups_url` output. Note: it takes several minutes for all dependencies and images to download and start.
+
 #### HCP Consul
 
-The HCP Consul cluster can be accessed via the outputs `consul_url` and
-`consul_root_token`.
+The HCP Consul cluster's UI can be accessed via the outputs `consul_url` and `consul_root_token`.
 
 #### Nomad
 
@@ -49,6 +46,11 @@ This example is running on nomad, which can be accessed via the outputs `nomad_u
 
 #### VM instances
 
-**Warning**: This instance, by default, is publicly accessible on port 8080 and 8081, make sure to delete it when done.
+To SSH to the VM/Consul client, write the private key to a file and use it to SSH:
 
-The Azure VM applications be accessed via the `hashicups_url` output, providing URL to the demo app.
+```bash
+pem=~/.ssh/hashicups.pem
+tf output -raw private_key_openssh > $pem
+chmod 400 $pem
+ssh -i $pem adminuser@$(tf output -raw vm_client_public_ip)
+```

--- a/examples/hcp-vm-demo/main.tf
+++ b/examples/hcp-vm-demo/main.tf
@@ -70,6 +70,11 @@ resource "hcp_consul_cluster_root_token" "token" {
   cluster_id = hcp_consul_cluster.main.id
 }
 
+resource "tls_private_key" "ssh" {
+  algorithm = "RSA"
+  rsa_bits  = 4096
+}
+
 module "vm_client" {
   source  = "hashicorp/hcp-consul/azurerm//modules/hcp-vm-client"
   version = "~> 0.2.0"
@@ -85,5 +90,6 @@ module "vm_client" {
   client_config_file = hcp_consul_cluster.main.consul_config_file
   client_ca_file     = hcp_consul_cluster.main.consul_ca_file
   root_token         = hcp_consul_cluster_root_token.token.secret_id
+  ssh_public_key     = tls_private_key.ssh.public_key_openssh
   consul_version     = hcp_consul_cluster.main.consul_version
 }

--- a/examples/hcp-vm-demo/output.tf
+++ b/examples/hcp-vm-demo/output.tf
@@ -16,10 +16,6 @@ output "hashicups_url" {
   value = "http://${module.vm_client.public_ip}"
 }
 
-output "next_steps" {
-  value = "Hashicups Application will be ready in ~5 minutes. Use 'terraform output consul_root_token' to retrieve the root token."
-}
-
 output "private_key_openssh" {
   value     = tls_private_key.ssh.private_key_openssh
   sensitive = true
@@ -27,4 +23,19 @@ output "private_key_openssh" {
 
 output "vm_client_public_ip" {
   value = module.vm_client.public_ip
+}
+
+output "next_steps" {
+  value = <<EOT
+Hashicups Application will be ready in ~5 minutes.
+
+Use 'terraform output consul_root_token' to retrieve the root token.
+
+To SSH into your VM:
+
+  pem=~/.ssh/hashicups.pem
+  tf output -raw private_key_openssh > $pem
+  chmod 400 $pem
+  ssh -i $pem adminuser@$(tf output -raw vm_client_public_ip)
+EOT
 }

--- a/examples/hcp-vm-demo/output.tf
+++ b/examples/hcp-vm-demo/output.tf
@@ -17,5 +17,14 @@ output "hashicups_url" {
 }
 
 output "next_steps" {
-  value = "Hashicups Application will be ready in ~2 minutes. Use 'terraform output consul_root_token' to retrieve the root token."
+  value = "Hashicups Application will be ready in ~5 minutes. Use 'terraform output consul_root_token' to retrieve the root token."
+}
+
+output "private_key_openssh" {
+  value     = tls_private_key.ssh.private_key_openssh
+  sensitive = true
+}
+
+output "vm_client_public_ip" {
+  value = module.vm_client.public_ip
 }

--- a/examples/hcp-vm-demo/providers.tf
+++ b/examples/hcp-vm-demo/providers.tf
@@ -13,6 +13,10 @@ terraform {
       source  = "hashicorp/hcp"
       version = ">= 0.23.1"
     }
+    tls = {
+      source  = "hashicorp/tls"
+      version = "~> 3.4.0"
+    }
   }
 
   required_version = ">= 1.0.11"
@@ -29,6 +33,8 @@ provider "azurerm" {
 provider "azuread" {}
 
 provider "hcp" {}
+
+provider "tls" {}
 
 provider "consul" {
   address    = hcp_consul_cluster.main.consul_public_endpoint_url

--- a/hcp-ui-templates/vm-existing-vnet/main.tf
+++ b/hcp-ui-templates/vm-existing-vnet/main.tf
@@ -137,10 +137,6 @@ output "hashicups_url" {
   value = "http://${module.vm_client.public_ip}"
 }
 
-output "next_steps" {
-  value = "Hashicups Application will be ready in ~5 minutes. Use 'terraform output consul_root_token' to retrieve the root token."
-}
-
 output "private_key_openssh" {
   value     = tls_private_key.ssh.private_key_openssh
   sensitive = true
@@ -148,4 +144,19 @@ output "private_key_openssh" {
 
 output "vm_client_public_ip" {
   value = module.vm_client.public_ip
+}
+
+output "next_steps" {
+  value = <<EOT
+Hashicups Application will be ready in ~5 minutes.
+
+Use 'terraform output consul_root_token' to retrieve the root token.
+
+To SSH into your VM:
+
+  pem=~/.ssh/hashicups.pem
+  tf output -raw private_key_openssh > $pem
+  chmod 400 $pem
+  ssh -i $pem adminuser@$(tf output -raw vm_client_public_ip)
+EOT
 }

--- a/hcp-ui-templates/vm-existing-vnet/main.tf
+++ b/hcp-ui-templates/vm-existing-vnet/main.tf
@@ -23,6 +23,10 @@ terraform {
       source  = "hashicorp/hcp"
       version = ">= 0.23.1"
     }
+    tls = {
+      source  = "hashicorp/tls"
+      version = "~> 3.4.0"
+    }
   }
 
   required_version = ">= 1.0.11"
@@ -36,6 +40,8 @@ provider "azurerm" {
 provider "azuread" {}
 
 provider "hcp" {}
+
+provider "tls" {}
 
 provider "consul" {
   address    = hcp_consul_cluster.main.consul_public_endpoint_url
@@ -90,6 +96,11 @@ resource "hcp_consul_cluster_root_token" "token" {
   cluster_id = hcp_consul_cluster.main.id
 }
 
+resource "tls_private_key" "ssh" {
+  algorithm = "RSA"
+  rsa_bits  = 4096
+}
+
 module "vm_client" {
   source  = "hashicorp/hcp-consul/azurerm//modules/hcp-vm-client"
   version = "~> 0.2.0"
@@ -105,6 +116,7 @@ module "vm_client" {
   client_config_file = hcp_consul_cluster.main.consul_config_file
   client_ca_file     = hcp_consul_cluster.main.consul_ca_file
   root_token         = hcp_consul_cluster_root_token.token.secret_id
+  ssh_public_key     = tls_private_key.ssh.public_key_openssh
   consul_version     = hcp_consul_cluster.main.consul_version
 }
 
@@ -126,5 +138,14 @@ output "hashicups_url" {
 }
 
 output "next_steps" {
-  value = "Hashicups Application will be ready in ~2 minutes. Use 'terraform output consul_root_token' to retrieve the root token."
+  value = "Hashicups Application will be ready in ~5 minutes. Use 'terraform output consul_root_token' to retrieve the root token."
+}
+
+output "private_key_openssh" {
+  value     = tls_private_key.ssh.private_key_openssh
+  sensitive = true
+}
+
+output "vm_client_public_ip" {
+  value = module.vm_client.public_ip
 }

--- a/hcp-ui-templates/vm/main.tf
+++ b/hcp-ui-templates/vm/main.tf
@@ -24,6 +24,10 @@ terraform {
       source  = "hashicorp/hcp"
       version = ">= 0.23.1"
     }
+    tls = {
+      source  = "hashicorp/tls"
+      version = "~> 3.4.0"
+    }
   }
 
   required_version = ">= 1.0.11"
@@ -37,6 +41,8 @@ provider "azurerm" {
 provider "azuread" {}
 
 provider "hcp" {}
+
+provider "tls" {}
 
 provider "consul" {
   address    = hcp_consul_cluster.main.consul_public_endpoint_url
@@ -115,6 +121,11 @@ resource "hcp_consul_cluster_root_token" "token" {
   cluster_id = hcp_consul_cluster.main.id
 }
 
+resource "tls_private_key" "ssh" {
+  algorithm = "RSA"
+  rsa_bits  = 4096
+}
+
 module "vm_client" {
   source  = "hashicorp/hcp-consul/azurerm//modules/hcp-vm-client"
   version = "~> 0.2.0"
@@ -130,6 +141,7 @@ module "vm_client" {
   client_config_file = hcp_consul_cluster.main.consul_config_file
   client_ca_file     = hcp_consul_cluster.main.consul_ca_file
   root_token         = hcp_consul_cluster_root_token.token.secret_id
+  ssh_public_key     = tls_private_key.ssh.public_key_openssh
   consul_version     = hcp_consul_cluster.main.consul_version
 }
 
@@ -151,5 +163,14 @@ output "hashicups_url" {
 }
 
 output "next_steps" {
-  value = "Hashicups Application will be ready in ~2 minutes. Use 'terraform output consul_root_token' to retrieve the root token."
+  value = "Hashicups Application will be ready in ~5 minutes. Use 'terraform output consul_root_token' to retrieve the root token."
+}
+
+output "private_key_openssh" {
+  value     = tls_private_key.ssh.private_key_openssh
+  sensitive = true
+}
+
+output "vm_client_public_ip" {
+  value = module.vm_client.public_ip
 }

--- a/hcp-ui-templates/vm/main.tf
+++ b/hcp-ui-templates/vm/main.tf
@@ -162,10 +162,6 @@ output "hashicups_url" {
   value = "http://${module.vm_client.public_ip}"
 }
 
-output "next_steps" {
-  value = "Hashicups Application will be ready in ~5 minutes. Use 'terraform output consul_root_token' to retrieve the root token."
-}
-
 output "private_key_openssh" {
   value     = tls_private_key.ssh.private_key_openssh
   sensitive = true
@@ -173,4 +169,19 @@ output "private_key_openssh" {
 
 output "vm_client_public_ip" {
   value = module.vm_client.public_ip
+}
+
+output "next_steps" {
+  value = <<EOT
+Hashicups Application will be ready in ~5 minutes.
+
+Use 'terraform output consul_root_token' to retrieve the root token.
+
+To SSH into your VM:
+
+  pem=~/.ssh/hashicups.pem
+  tf output -raw private_key_openssh > $pem
+  chmod 400 $pem
+  ssh -i $pem adminuser@$(tf output -raw vm_client_public_ip)
+EOT
 }

--- a/modules/hcp-vm-client/main.tf
+++ b/modules/hcp-vm-client/main.tf
@@ -75,7 +75,7 @@ resource "azurerm_linux_virtual_machine" "vm" {
 
   admin_ssh_key {
     username   = "adminuser"
-    public_key = file("~/.ssh/id_rsa.pub")
+    public_key = var.ssh_public_key
   }
 
   os_disk {

--- a/modules/hcp-vm-client/variables.tf
+++ b/modules/hcp-vm-client/variables.tf
@@ -40,6 +40,11 @@ variable "root_token" {
   description = "The Consul Secret ID of the Consul root token"
 }
 
+variable "ssh_public_key" {
+  type        = string
+  description = "The public key data for SSH'ing to the VM"
+}
+
 variable "consul_version" {
   type        = string
   description = "The Consul version of the HCP servers"

--- a/test/hcp/testdata/vm-existing-vnet.golden
+++ b/test/hcp/testdata/vm-existing-vnet.golden
@@ -137,10 +137,6 @@ output "hashicups_url" {
   value = "http://${module.vm_client.public_ip}"
 }
 
-output "next_steps" {
-  value = "Hashicups Application will be ready in ~5 minutes. Use 'terraform output consul_root_token' to retrieve the root token."
-}
-
 output "private_key_openssh" {
   value     = tls_private_key.ssh.private_key_openssh
   sensitive = true
@@ -148,4 +144,19 @@ output "private_key_openssh" {
 
 output "vm_client_public_ip" {
   value = module.vm_client.public_ip
+}
+
+output "next_steps" {
+  value = <<EOT
+Hashicups Application will be ready in ~5 minutes.
+
+Use 'terraform output consul_root_token' to retrieve the root token.
+
+To SSH into your VM:
+
+  pem=~/.ssh/hashicups.pem
+  tf output -raw private_key_openssh > $pem
+  chmod 400 $pem
+  ssh -i $pem adminuser@$(tf output -raw vm_client_public_ip)
+EOT
 }

--- a/test/hcp/testdata/vm-existing-vnet.golden
+++ b/test/hcp/testdata/vm-existing-vnet.golden
@@ -23,6 +23,10 @@ terraform {
       source  = "hashicorp/hcp"
       version = ">= 0.23.1"
     }
+    tls = {
+      source  = "hashicorp/tls"
+      version = "~> 3.4.0"
+    }
   }
 
   required_version = ">= 1.0.11"
@@ -36,6 +40,8 @@ provider "azurerm" {
 provider "azuread" {}
 
 provider "hcp" {}
+
+provider "tls" {}
 
 provider "consul" {
   address    = hcp_consul_cluster.main.consul_public_endpoint_url
@@ -90,6 +96,11 @@ resource "hcp_consul_cluster_root_token" "token" {
   cluster_id = hcp_consul_cluster.main.id
 }
 
+resource "tls_private_key" "ssh" {
+  algorithm = "RSA"
+  rsa_bits  = 4096
+}
+
 module "vm_client" {
   source  = "hashicorp/hcp-consul/azurerm//modules/hcp-vm-client"
   version = "~> 0.2.0"
@@ -105,6 +116,7 @@ module "vm_client" {
   client_config_file = hcp_consul_cluster.main.consul_config_file
   client_ca_file     = hcp_consul_cluster.main.consul_ca_file
   root_token         = hcp_consul_cluster_root_token.token.secret_id
+  ssh_public_key     = tls_private_key.ssh.public_key_openssh
   consul_version     = hcp_consul_cluster.main.consul_version
 }
 
@@ -126,5 +138,14 @@ output "hashicups_url" {
 }
 
 output "next_steps" {
-  value = "Hashicups Application will be ready in ~2 minutes. Use 'terraform output consul_root_token' to retrieve the root token."
+  value = "Hashicups Application will be ready in ~5 minutes. Use 'terraform output consul_root_token' to retrieve the root token."
+}
+
+output "private_key_openssh" {
+  value     = tls_private_key.ssh.private_key_openssh
+  sensitive = true
+}
+
+output "vm_client_public_ip" {
+  value = module.vm_client.public_ip
 }

--- a/test/hcp/testdata/vm.golden
+++ b/test/hcp/testdata/vm.golden
@@ -24,6 +24,10 @@ terraform {
       source  = "hashicorp/hcp"
       version = ">= 0.23.1"
     }
+    tls = {
+      source  = "hashicorp/tls"
+      version = "~> 3.4.0"
+    }
   }
 
   required_version = ">= 1.0.11"
@@ -37,6 +41,8 @@ provider "azurerm" {
 provider "azuread" {}
 
 provider "hcp" {}
+
+provider "tls" {}
 
 provider "consul" {
   address    = hcp_consul_cluster.main.consul_public_endpoint_url
@@ -115,6 +121,11 @@ resource "hcp_consul_cluster_root_token" "token" {
   cluster_id = hcp_consul_cluster.main.id
 }
 
+resource "tls_private_key" "ssh" {
+  algorithm = "RSA"
+  rsa_bits  = 4096
+}
+
 module "vm_client" {
   source  = "hashicorp/hcp-consul/azurerm//modules/hcp-vm-client"
   version = "~> 0.2.0"
@@ -130,6 +141,7 @@ module "vm_client" {
   client_config_file = hcp_consul_cluster.main.consul_config_file
   client_ca_file     = hcp_consul_cluster.main.consul_ca_file
   root_token         = hcp_consul_cluster_root_token.token.secret_id
+  ssh_public_key     = tls_private_key.ssh.public_key_openssh
   consul_version     = hcp_consul_cluster.main.consul_version
 }
 
@@ -151,5 +163,14 @@ output "hashicups_url" {
 }
 
 output "next_steps" {
-  value = "Hashicups Application will be ready in ~2 minutes. Use 'terraform output consul_root_token' to retrieve the root token."
+  value = "Hashicups Application will be ready in ~5 minutes. Use 'terraform output consul_root_token' to retrieve the root token."
+}
+
+output "private_key_openssh" {
+  value     = tls_private_key.ssh.private_key_openssh
+  sensitive = true
+}
+
+output "vm_client_public_ip" {
+  value = module.vm_client.public_ip
 }

--- a/test/hcp/testdata/vm.golden
+++ b/test/hcp/testdata/vm.golden
@@ -162,10 +162,6 @@ output "hashicups_url" {
   value = "http://${module.vm_client.public_ip}"
 }
 
-output "next_steps" {
-  value = "Hashicups Application will be ready in ~5 minutes. Use 'terraform output consul_root_token' to retrieve the root token."
-}
-
 output "private_key_openssh" {
   value     = tls_private_key.ssh.private_key_openssh
   sensitive = true
@@ -173,4 +169,19 @@ output "private_key_openssh" {
 
 output "vm_client_public_ip" {
   value = module.vm_client.public_ip
+}
+
+output "next_steps" {
+  value = <<EOT
+Hashicups Application will be ready in ~5 minutes.
+
+Use 'terraform output consul_root_token' to retrieve the root token.
+
+To SSH into your VM:
+
+  pem=~/.ssh/hashicups.pem
+  tf output -raw private_key_openssh > $pem
+  chmod 400 $pem
+  ssh -i $pem adminuser@$(tf output -raw vm_client_public_ip)
+EOT
 }


### PR DESCRIPTION
Before this change, we used a pem from `~/.ssh/id_rsa.pub`. That was fine, but windows users won't have it. And it adds a dependency (most people will have one but.. still). This uses a TF TLS provider to make one of the fly for the HashiCups VM. Tested by creating a new cluster + VM from scratch and SSHing into it with:

```
pem=~/.ssh/hashicups.pem
tf output -raw private_key_openssh > $pem
chmod 400 $pem
ssh -i $pem adminuser@$(tf output -raw vm_client_public_ip)
```