### PR TITLE
added subscription_id to provider

### DIFF
--- a/hcp-ui-templates/vm-existing-vnet/main.tf
+++ b/hcp-ui-templates/vm-existing-vnet/main.tf
@@ -34,6 +34,7 @@ terraform {
 }
 
 provider "azurerm" {
+  subscription_id = local.subscription_id
   features {}
 }
 

--- a/scripts/generate_ui_templates.sh
+++ b/scripts/generate_ui_templates.sh
@@ -58,7 +58,9 @@ generate() {
   file=hcp-ui-templates/$1-existing-vnet/main.tf
   mkdir -p $(dirname $file)
   generate_existing_vnet_locals $1 > $file
-  generate_existing_vnet_terraform $1 >> $file
+  # for the existing VNET template, we want to be sure to use the correct subscription
+  generate_existing_vnet_terraform $1 \
+    | sed 's/  features {}/  subscription_id = local.subscription_id\n  features {}/' >> $file
 
 }
 

--- a/test/hcp/testdata/vm-existing-vnet.golden
+++ b/test/hcp/testdata/vm-existing-vnet.golden
@@ -34,6 +34,7 @@ terraform {
 }
 
 provider "azurerm" {
+  subscription_id = local.subscription_id
   features {}
 }
 


### PR DESCRIPTION
When having multiple subscription it makes sense to explicitly mention the subscription id when configuring the provider since it is part of the variables we specify anyway.