### PR TITLE
Remove ssh key from vm

### DIFF
--- a/examples/hcp-vm-demo/README.md
+++ b/examples/hcp-vm-demo/README.md
@@ -43,14 +43,3 @@ The HCP Consul cluster's UI can be accessed via the outputs `consul_url` and `co
 #### Nomad
 
 This example is running on nomad, which can be accessed via the outputs `nomad_url` with the username `nomad` and `consul_root_token`.
-
-#### VM instances
-
-To SSH to the VM/Consul client, write the private key to a file and use it to SSH:
-
-```bash
-pem=~/.ssh/hashicups.pem
-tf output -raw private_key_openssh > $pem
-chmod 400 $pem
-ssh -i $pem adminuser@$(tf output -raw vm_client_public_ip)
-```

--- a/examples/hcp-vm-demo/main.tf
+++ b/examples/hcp-vm-demo/main.tf
@@ -70,11 +70,6 @@ resource "hcp_consul_cluster_root_token" "token" {
   cluster_id = hcp_consul_cluster.main.id
 }
 
-resource "tls_private_key" "ssh" {
-  algorithm = "RSA"
-  rsa_bits  = 4096
-}
-
 module "vm_client" {
   source  = "hashicorp/hcp-consul/azurerm//modules/hcp-vm-client"
   version = "~> 0.2.0"
@@ -90,6 +85,5 @@ module "vm_client" {
   client_config_file = hcp_consul_cluster.main.consul_config_file
   client_ca_file     = hcp_consul_cluster.main.consul_ca_file
   root_token         = hcp_consul_cluster_root_token.token.secret_id
-  ssh_public_key     = tls_private_key.ssh.public_key_openssh
   consul_version     = hcp_consul_cluster.main.consul_version
 }

--- a/examples/hcp-vm-demo/output.tf
+++ b/examples/hcp-vm-demo/output.tf
@@ -16,11 +16,6 @@ output "hashicups_url" {
   value = "http://${module.vm_client.public_ip}"
 }
 
-output "private_key_openssh" {
-  value     = tls_private_key.ssh.private_key_openssh
-  sensitive = true
-}
-
 output "vm_client_public_ip" {
   value = module.vm_client.public_ip
 }
@@ -30,12 +25,5 @@ output "next_steps" {
 Hashicups Application will be ready in ~5 minutes.
 
 Use 'terraform output consul_root_token' to retrieve the root token.
-
-To SSH into your VM:
-
-  pem=~/.ssh/hashicups.pem
-  tf output -raw private_key_openssh > $pem
-  chmod 400 $pem
-  ssh -i $pem adminuser@$(tf output -raw vm_client_public_ip)
 EOT
 }

--- a/examples/hcp-vm-demo/providers.tf
+++ b/examples/hcp-vm-demo/providers.tf
@@ -13,10 +13,6 @@ terraform {
       source  = "hashicorp/hcp"
       version = ">= 0.23.1"
     }
-    tls = {
-      source  = "hashicorp/tls"
-      version = "~> 3.4.0"
-    }
   }
 
   required_version = ">= 1.0.11"

--- a/hcp-ui-templates/vm-existing-vnet/main.tf
+++ b/hcp-ui-templates/vm-existing-vnet/main.tf
@@ -23,10 +23,6 @@ terraform {
       source  = "hashicorp/hcp"
       version = ">= 0.23.1"
     }
-    tls = {
-      source  = "hashicorp/tls"
-      version = "~> 3.4.0"
-    }
   }
 
   required_version = ">= 1.0.11"
@@ -97,11 +93,6 @@ resource "hcp_consul_cluster_root_token" "token" {
   cluster_id = hcp_consul_cluster.main.id
 }
 
-resource "tls_private_key" "ssh" {
-  algorithm = "RSA"
-  rsa_bits  = 4096
-}
-
 module "vm_client" {
   source  = "hashicorp/hcp-consul/azurerm//modules/hcp-vm-client"
   version = "~> 0.2.0"
@@ -117,7 +108,6 @@ module "vm_client" {
   client_config_file = hcp_consul_cluster.main.consul_config_file
   client_ca_file     = hcp_consul_cluster.main.consul_ca_file
   root_token         = hcp_consul_cluster_root_token.token.secret_id
-  ssh_public_key     = tls_private_key.ssh.public_key_openssh
   consul_version     = hcp_consul_cluster.main.consul_version
 }
 
@@ -138,11 +128,6 @@ output "hashicups_url" {
   value = "http://${module.vm_client.public_ip}"
 }
 
-output "private_key_openssh" {
-  value     = tls_private_key.ssh.private_key_openssh
-  sensitive = true
-}
-
 output "vm_client_public_ip" {
   value = module.vm_client.public_ip
 }
@@ -152,12 +137,5 @@ output "next_steps" {
 Hashicups Application will be ready in ~5 minutes.
 
 Use 'terraform output consul_root_token' to retrieve the root token.
-
-To SSH into your VM:
-
-  pem=~/.ssh/hashicups.pem
-  tf output -raw private_key_openssh > $pem
-  chmod 400 $pem
-  ssh -i $pem adminuser@$(tf output -raw vm_client_public_ip)
 EOT
 }

--- a/hcp-ui-templates/vm/main.tf
+++ b/hcp-ui-templates/vm/main.tf
@@ -24,10 +24,6 @@ terraform {
       source  = "hashicorp/hcp"
       version = ">= 0.23.1"
     }
-    tls = {
-      source  = "hashicorp/tls"
-      version = "~> 3.4.0"
-    }
   }
 
   required_version = ">= 1.0.11"
@@ -121,11 +117,6 @@ resource "hcp_consul_cluster_root_token" "token" {
   cluster_id = hcp_consul_cluster.main.id
 }
 
-resource "tls_private_key" "ssh" {
-  algorithm = "RSA"
-  rsa_bits  = 4096
-}
-
 module "vm_client" {
   source  = "hashicorp/hcp-consul/azurerm//modules/hcp-vm-client"
   version = "~> 0.2.0"
@@ -141,7 +132,6 @@ module "vm_client" {
   client_config_file = hcp_consul_cluster.main.consul_config_file
   client_ca_file     = hcp_consul_cluster.main.consul_ca_file
   root_token         = hcp_consul_cluster_root_token.token.secret_id
-  ssh_public_key     = tls_private_key.ssh.public_key_openssh
   consul_version     = hcp_consul_cluster.main.consul_version
 }
 
@@ -162,11 +152,6 @@ output "hashicups_url" {
   value = "http://${module.vm_client.public_ip}"
 }
 
-output "private_key_openssh" {
-  value     = tls_private_key.ssh.private_key_openssh
-  sensitive = true
-}
-
 output "vm_client_public_ip" {
   value = module.vm_client.public_ip
 }
@@ -176,12 +161,5 @@ output "next_steps" {
 Hashicups Application will be ready in ~5 minutes.
 
 Use 'terraform output consul_root_token' to retrieve the root token.
-
-To SSH into your VM:
-
-  pem=~/.ssh/hashicups.pem
-  tf output -raw private_key_openssh > $pem
-  chmod 400 $pem
-  ssh -i $pem adminuser@$(tf output -raw vm_client_public_ip)
 EOT
 }

--- a/modules/hcp-vm-client/main.tf
+++ b/modules/hcp-vm-client/main.tf
@@ -73,11 +73,6 @@ resource "azurerm_linux_virtual_machine" "vm" {
   admin_username        = "adminuser"
   network_interface_ids = [azurerm_network_interface.client_nic.id]
 
-  admin_ssh_key {
-    username   = "adminuser"
-    public_key = var.ssh_public_key
-  }
-
   os_disk {
     caching              = "ReadWrite"
     storage_account_type = "Standard_LRS"

--- a/modules/hcp-vm-client/variables.tf
+++ b/modules/hcp-vm-client/variables.tf
@@ -40,11 +40,6 @@ variable "root_token" {
   description = "The Consul Secret ID of the Consul root token"
 }
 
-variable "ssh_public_key" {
-  type        = string
-  description = "The public key data for SSH'ing to the VM"
-}
-
 variable "consul_version" {
   type        = string
   description = "The Consul version of the HCP servers"

--- a/test/hcp/testdata/vm-existing-vnet.golden
+++ b/test/hcp/testdata/vm-existing-vnet.golden
@@ -23,10 +23,6 @@ terraform {
       source  = "hashicorp/hcp"
       version = ">= 0.23.1"
     }
-    tls = {
-      source  = "hashicorp/tls"
-      version = "~> 3.4.0"
-    }
   }
 
   required_version = ">= 1.0.11"
@@ -97,11 +93,6 @@ resource "hcp_consul_cluster_root_token" "token" {
   cluster_id = hcp_consul_cluster.main.id
 }
 
-resource "tls_private_key" "ssh" {
-  algorithm = "RSA"
-  rsa_bits  = 4096
-}
-
 module "vm_client" {
   source  = "hashicorp/hcp-consul/azurerm//modules/hcp-vm-client"
   version = "~> 0.2.0"
@@ -117,7 +108,6 @@ module "vm_client" {
   client_config_file = hcp_consul_cluster.main.consul_config_file
   client_ca_file     = hcp_consul_cluster.main.consul_ca_file
   root_token         = hcp_consul_cluster_root_token.token.secret_id
-  ssh_public_key     = tls_private_key.ssh.public_key_openssh
   consul_version     = hcp_consul_cluster.main.consul_version
 }
 
@@ -138,11 +128,6 @@ output "hashicups_url" {
   value = "http://${module.vm_client.public_ip}"
 }
 
-output "private_key_openssh" {
-  value     = tls_private_key.ssh.private_key_openssh
-  sensitive = true
-}
-
 output "vm_client_public_ip" {
   value = module.vm_client.public_ip
 }
@@ -152,12 +137,5 @@ output "next_steps" {
 Hashicups Application will be ready in ~5 minutes.
 
 Use 'terraform output consul_root_token' to retrieve the root token.
-
-To SSH into your VM:
-
-  pem=~/.ssh/hashicups.pem
-  tf output -raw private_key_openssh > $pem
-  chmod 400 $pem
-  ssh -i $pem adminuser@$(tf output -raw vm_client_public_ip)
 EOT
 }

--- a/test/hcp/testdata/vm.golden
+++ b/test/hcp/testdata/vm.golden
@@ -24,10 +24,6 @@ terraform {
       source  = "hashicorp/hcp"
       version = ">= 0.23.1"
     }
-    tls = {
-      source  = "hashicorp/tls"
-      version = "~> 3.4.0"
-    }
   }
 
   required_version = ">= 1.0.11"
@@ -121,11 +117,6 @@ resource "hcp_consul_cluster_root_token" "token" {
   cluster_id = hcp_consul_cluster.main.id
 }
 
-resource "tls_private_key" "ssh" {
-  algorithm = "RSA"
-  rsa_bits  = 4096
-}
-
 module "vm_client" {
   source  = "hashicorp/hcp-consul/azurerm//modules/hcp-vm-client"
   version = "~> 0.2.0"
@@ -141,7 +132,6 @@ module "vm_client" {
   client_config_file = hcp_consul_cluster.main.consul_config_file
   client_ca_file     = hcp_consul_cluster.main.consul_ca_file
   root_token         = hcp_consul_cluster_root_token.token.secret_id
-  ssh_public_key     = tls_private_key.ssh.public_key_openssh
   consul_version     = hcp_consul_cluster.main.consul_version
 }
 
@@ -162,11 +152,6 @@ output "hashicups_url" {
   value = "http://${module.vm_client.public_ip}"
 }
 
-output "private_key_openssh" {
-  value     = tls_private_key.ssh.private_key_openssh
-  sensitive = true
-}
-
 output "vm_client_public_ip" {
   value = module.vm_client.public_ip
 }
@@ -176,12 +161,5 @@ output "next_steps" {
 Hashicups Application will be ready in ~5 minutes.
 
 Use 'terraform output consul_root_token' to retrieve the root token.
-
-To SSH into your VM:
-
-  pem=~/.ssh/hashicups.pem
-  tf output -raw private_key_openssh > $pem
-  chmod 400 $pem
-  ssh -i $pem adminuser@$(tf output -raw vm_client_public_ip)
 EOT
 }


### PR DESCRIPTION
if users don't have write auth for the SSH directory, the TLS provider fails: https://hashicorp.slack.com/archives/C02590D9TD0/p1653681403300049

It's easier, for now, to just create the VM and users can SSH into it with Azure bastion of whatever ssh solution the cloud provider offers