### PR TITLE
HCS-3174: Add AKS client module and example

### DIFF
--- a/examples/hcp-aks-demo/README.md
+++ b/examples/hcp-aks-demo/README.md
@@ -1,0 +1,43 @@
+# hcp-aks-demo
+
+This Terraform example stands up a full deployment of a HCP Consul cluster connected to an Azure AKS cluster.
+
+### Prerequisites
+
+1. Create a HCP Service Key and set the required environment variables
+
+```
+export HCP_CLIENT_ID=...
+export HCP_CLIENT_SECRET=...
+```
+
+2. Log into Azure via the Azure CLI, and set the correct subscription. More details can be found on the [Azure Terraform provider documentation](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/guides/azure_cli).
+
+```
+az login
+az account set --subscription="SUBSCRIPTION_ID"
+```
+
+The user must be assigned a [role granting authorization to create Service Principals](https://docs.microsoft.com/en-us/graph/api/serviceprincipal-post-serviceprincipals?view=graph-rest-1.0&tabs=http#permissions). For example: `Cloud Application Administrator` or `Application Administrator`.
+
+### Deployment
+
+1. Initialize and apply the Terraform configuration
+
+```
+terraform init && terraform apply
+```
+
+### Accessing the Deployment
+
+#### HashiCups
+
+TODO: This is not yet implemented.
+
+#### HCP Consul
+
+The HCP Consul cluster's UI can be accessed via the outputs `consul_url` and `consul_root_token`.
+
+#### AKS Cluster
+
+The AKS cluster can be accessed via TODO

--- a/examples/hcp-aks-demo/main.tf
+++ b/examples/hcp-aks-demo/main.tf
@@ -42,10 +42,8 @@ resource "hcp_hvn" "hvn" {
 }
 
 module "hcp_peering" {
-  #source  = "hashicorp/hcp-consul/azurerm"
-  #version = "~> X.X.X"
-  # TODO: Revert to above once this is published
-  source  = "../.."
+  source  = "hashicorp/hcp-consul/azurerm"
+  version = "~> 0.2.0"
 
   tenant_id       = data.azurerm_subscription.current.tenant_id
   subscription_id = data.azurerm_subscription.current.subscription_id

--- a/examples/hcp-aks-demo/main.tf
+++ b/examples/hcp-aks-demo/main.tf
@@ -1,0 +1,114 @@
+data "azurerm_subscription" "current" {}
+
+resource "azurerm_resource_group" "rg" {
+  name     = "${var.cluster_id}-gid"
+  location = var.network_region
+}
+
+resource "azurerm_route_table" "rt" {
+  name                = "${var.cluster_id}-rt"
+  resource_group_name = azurerm_resource_group.rg.name
+  location            = azurerm_resource_group.rg.location
+}
+
+resource "azurerm_network_security_group" "nsg" {
+  name                = "${var.cluster_id}-nsg"
+  resource_group_name = azurerm_resource_group.rg.name
+  location            = azurerm_resource_group.rg.location
+}
+
+module "network" {
+  source              = "Azure/vnet/azurerm"
+  resource_group_name = azurerm_resource_group.rg.name
+  address_space       = var.vnet_cidrs
+  subnet_prefixes     = values(var.vnet_subnets)
+  subnet_names        = keys(var.vnet_subnets)
+  vnet_name           = "${var.cluster_id}-vnet"
+
+  # Every subnet will share a single route table
+  route_tables_ids = { for i, subnet in keys(var.vnet_subnets) : subnet => azurerm_route_table.rt.id }
+
+  # Every subnet will share a single network security group
+  nsg_ids = { for i, subnet in keys(var.vnet_subnets) : subnet => azurerm_network_security_group.nsg.id }
+
+  depends_on = [azurerm_resource_group.rg]
+}
+
+resource "hcp_hvn" "hvn" {
+  hvn_id         = var.hvn_id
+  cloud_provider = "azure"
+  region         = var.hvn_region
+  cidr_block     = var.hvn_cidr_block
+}
+
+module "hcp_peering" {
+  #source  = "hashicorp/hcp-consul/azurerm"
+  #version = "~> X.X.X"
+  # TODO: Revert to above once this is published
+  source  = "../.."
+
+  tenant_id       = data.azurerm_subscription.current.tenant_id
+  subscription_id = data.azurerm_subscription.current.subscription_id
+  hvn             = hcp_hvn.hvn
+  vnet_rg         = azurerm_resource_group.rg.name
+  vnet_id         = module.network.vnet_id
+  subnet_ids      = module.network.vnet_subnets
+  prefix          = var.cluster_id
+  security_group_names = [azurerm_network_security_group.nsg.name]
+}
+
+resource "hcp_consul_cluster" "main" {
+  cluster_id      = var.cluster_id
+  hvn_id          = hcp_hvn.hvn.hvn_id
+  public_endpoint = true
+  tier            = var.tier
+}
+
+resource "hcp_consul_cluster_root_token" "token" {
+  cluster_id = hcp_consul_cluster.main.id
+}
+
+module "aks" {
+  source                         = "Azure/aks/azurerm"
+  version                        = "4.14.0"
+  resource_group_name            = azurerm_resource_group.rg.name 
+  prefix                         = var.cluster_id
+  cluster_name                   = var.cluster_id
+  agents_size                    = "standard_d2s_v5"
+  network_plugin                 = "azure"
+  vnet_subnet_id                 = module.network.vnet_subnets[0]
+  os_disk_size_gb                = 50
+  private_cluster_enabled        = false
+  agents_count                   = 2
+  sku_tier                       = "Free"
+  agents_max_pods                = 100
+  agents_pool_name               = "nodepool"
+  network_policy                 = "azure"
+  net_profile_dns_service_ip     = "10.0.0.10"
+  net_profile_docker_bridge_cidr = "170.10.0.1/16"
+  net_profile_service_cidr       = "10.0.0.0/24"
+
+  depends_on = [module.network]
+}
+
+module "aks_consul_client" {
+  #source  = "hashicorp/hcp-consul/azurerm//modules/hcp-aks-client"
+  #version = "~> X.X.X"
+  # TODO: Revert to above once this is published
+  source  = "../../modules/hcp-aks-client"
+
+  cluster_id       = hcp_consul_cluster.main.cluster_id
+  consul_hosts     = jsondecode(base64decode(hcp_consul_cluster.main.consul_config_file))["retry_join"]
+  k8s_api_endpoint = module.aks.host
+  consul_version   = hcp_consul_cluster.main.consul_version
+
+  boostrap_acl_token    = hcp_consul_cluster_root_token.token.secret_id
+  consul_ca_file        = base64decode(hcp_consul_cluster.main.consul_ca_file)
+  datacenter            = hcp_consul_cluster.main.datacenter
+  gossip_encryption_key = jsondecode(base64decode(hcp_consul_cluster.main.consul_config_file))["encrypt"]
+
+  # The AKS node group will fail to create if the clients are
+  # created at the same time. This forces the client to wait until
+  # the node group is successfully created.
+  depends_on = [module.aks]
+}

--- a/examples/hcp-aks-demo/output.tf
+++ b/examples/hcp-aks-demo/output.tf
@@ -1,0 +1,20 @@
+
+output "consul_root_token" {
+  value     = hcp_consul_cluster_root_token.token.secret_id
+  sensitive = true
+}
+
+output "consul_url" {
+  value = hcp_consul_cluster.main.consul_public_endpoint_url
+}
+
+# TODO: Implement Hashicups and add a node to the "next_steps" output below 
+#output "hashicups_url" {
+#  value = "http://${module.vm_client.public_ip}"
+#}
+
+output "next_steps" {
+  value = <<EOT
+Use 'terraform output consul_root_token' to retrieve the root token.
+EOT
+}

--- a/examples/hcp-aks-demo/providers.tf
+++ b/examples/hcp-aks-demo/providers.tf
@@ -1,0 +1,77 @@
+terraform {
+  required_providers {
+    azurerm = {
+      source  = "hashicorp/azurerm"
+      version = "~> 2.65"
+      configuration_aliases = [azurerm.azure]
+    }
+    azuread = {
+      source  = "hashicorp/azuread"
+      version = "~> 2.14"
+    }
+    hcp = {
+      source  = "hashicorp/hcp"
+      version = ">= 0.23.1"
+    }
+    kubernetes = {
+      source  = "hashicorp/kubernetes"
+      version = ">= 2.4.1"
+    }
+    helm = {
+      source  = "hashicorp/helm"
+      version = ">= 2.3.0"
+    }
+    kubectl = {
+      source  = "gavinbunney/kubectl"
+      version = ">= 1.11.3"
+    }
+  }
+
+  required_version = ">= 1.0.11"
+
+  provider_meta "hcp" {
+    module_name = "hcp-consul"
+  }
+}
+
+provider "helm" {
+  kubernetes {
+    host                   = module.aks.host
+    client_certificate     = base64decode(module.aks.client_certificate)
+    cluster_ca_certificate = base64decode(module.aks.cluster_ca_certificate)
+    client_key             = base64decode(module.aks.client_key)
+    username               = module.aks.admin_username
+    password               = module.aks.admin_password
+  }
+}
+
+provider "kubernetes" {
+  host                   = module.aks.host
+  client_certificate     = base64decode(module.aks.client_certificate)
+  client_key             = base64decode(module.aks.client_key)
+  cluster_ca_certificate = base64decode(module.aks.cluster_ca_certificate)
+  username               = module.aks.admin_username
+  password               = module.aks.admin_password
+}
+
+provider "kubectl" {
+  host                   = module.aks.host
+  cluster_ca_certificate = base64decode(module.aks.cluster_ca_certificate)
+  load_config_file       = false
+  username               = module.aks.admin_username
+  password               = module.aks.admin_password
+}
+
+provider "azurerm" {
+  features {}
+}
+
+provider "azuread" {}
+
+provider "hcp" {}
+
+provider "consul" {
+  address    = hcp_consul_cluster.main.consul_public_endpoint_url
+  datacenter = hcp_consul_cluster.main.datacenter
+  token      = hcp_consul_cluster_root_token.token.secret_id
+}

--- a/examples/hcp-aks-demo/variables.tf
+++ b/examples/hcp-aks-demo/variables.tf
@@ -1,0 +1,51 @@
+variable "network_region" {
+  type        = string
+  description = "the network region"
+  default     = "West US 2"
+}
+
+variable "hvn_region" {
+  type        = string
+  description = "the hvn region"
+  default     = "westus2"
+}
+
+variable "hvn_id" {
+  type        = string
+  description = "the hvn id"
+  default     = "hvn-foobar"
+}
+
+variable "hvn_cidr_block" {
+  type        = string
+  description = "The cidr block of the hvn"
+  default     = "172.25.16.0/20"
+}
+
+variable "cluster_id" {
+  type        = string
+  description = "The cluster id is unique. All other unique values will be derived from this (resource group, vnet etc)"
+  default     = "hcp-azure"
+}
+
+variable "tier" {
+  type        = string
+  description = "The HCP Consul tier to use when creating a Consul cluster"
+  default     = "development"
+}
+
+variable "vnet_cidrs" {
+  type        = list(string)
+  description = "The ciders of the vnet. This should make sense with vnet_subnets"
+  default     = ["10.0.0.0/16"]
+}
+
+variable "vnet_subnets" {
+  type        = map(string)
+  description = "The subnets associated with the vnet"
+  default = {
+    "subnet1" = "10.0.1.0/24",
+    "subnet2" = "10.0.2.0/24",
+    "subnet3" = "10.0.3.0/24",
+  }
+}

--- a/modules/hcp-aks-client/README.md
+++ b/modules/hcp-aks-client/README.md
@@ -1,0 +1,8 @@
+## hcp-aks-client
+
+A Terraform module used to install the Consul Helm chart onto a Kubernetes
+cluster.
+
+This module is intended for demonstration purposes only at the moment.  While
+the Consul clients will be deployed secure-by-default, the limited configuration
+options presented by the module are to aid a user in quickly getting started.

--- a/modules/hcp-aks-client/main.tf
+++ b/modules/hcp-aks-client/main.tf
@@ -1,0 +1,34 @@
+resource "kubernetes_secret" "consul_secrets" {
+  metadata {
+    name = "${var.cluster_id}-hcp"
+  }
+
+  data = {
+    caCert              = var.consul_ca_file
+    gossipEncryptionKey = var.gossip_encryption_key
+    bootstrapToken      = var.boostrap_acl_token
+  }
+
+  type = "Opaque"
+}
+
+resource "helm_release" "consul" {
+  name       = "consul"
+  repository = "https://helm.releases.hashicorp.com"
+  version    = var.chart_version
+  chart      = "consul"
+
+  values = [
+    templatefile("${path.module}/templates/consul.tpl", {
+      datacenter       = var.datacenter
+      consul_hosts     = jsonencode(var.consul_hosts)
+      cluster_id       = var.cluster_id
+      k8s_api_endpoint = var.k8s_api_endpoint
+      consul_version   = substr(var.consul_version, 1, -1)
+    })
+  ]
+
+  # Helm installation relies on the Kuberenetes secret being
+  # available.
+  depends_on = [kubernetes_secret.consul_secrets]
+}

--- a/modules/hcp-aks-client/providers.tf
+++ b/modules/hcp-aks-client/providers.tf
@@ -1,0 +1,13 @@
+terraform {
+  required_providers {
+    kubernetes = {
+      source  = "hashicorp/kubernetes"
+      version = ">= 2.4.1"
+    }
+
+    helm = {
+      source  = "hashicorp/helm"
+      version = ">= 2.3.0"
+    }
+  }
+}

--- a/modules/hcp-aks-client/templates/consul.tpl
+++ b/modules/hcp-aks-client/templates/consul.tpl
@@ -1,0 +1,41 @@
+global:
+  enabled: false
+  name: consul
+  datacenter: ${datacenter}
+  image: "hashicorp/consul-enterprise:${consul_version}-ent"
+  acls:
+    manageSystemACLs: true
+    bootstrapToken:
+      secretName: ${cluster_id}-hcp
+      secretKey: bootstrapToken
+  tls:
+    enabled: true
+    enableAutoEncrypt: true
+    caCert:
+      secretName: ${cluster_id}-hcp
+      secretKey: caCert
+  gossipEncryption:
+    secretName: ${cluster_id}-hcp
+    secretKey: gossipEncryptionKey
+
+externalServers:
+  enabled: true
+  hosts: ${consul_hosts}
+  httpsPort: 443
+  useSystemRoots: true
+  k8sAuthMethodHost: ${k8s_api_endpoint}
+
+server:
+  enabled: false
+
+client:
+  enabled: true
+  join: ${consul_hosts}
+  nodeMeta:
+    terraform-module: "hcp-aks-client"
+
+connectInject:
+  enabled: true
+
+controller:
+  enabled: true

--- a/modules/hcp-aks-client/variables.tf
+++ b/modules/hcp-aks-client/variables.tf
@@ -1,0 +1,57 @@
+/*
+ *
+ * Required Variables
+ *
+ */
+
+variable "boostrap_acl_token" {
+  type        = string
+  description = "The ACL bootstrap token used to create necessary ACL tokens for the Helm chart"
+}
+
+variable "gossip_encryption_key" {
+  type        = string
+  description = "The gossip encryption key of the Consul cluster"
+}
+
+variable "consul_ca_file" {
+  type        = string
+  description = "The Consul CA certificate bundle used to validate TLS connections"
+}
+
+variable "datacenter" {
+  type        = string
+  description = "The name of the Consul datacenter that client agents should register as"
+}
+
+variable "consul_hosts" {
+  type        = list(string)
+  description = "A list of DNS addresses that clients should use to join the Consul cluster"
+}
+
+variable "k8s_api_endpoint" {
+  type        = string
+  description = "The Kubernetes API endpoint for the Kubernetes cluster"
+}
+
+variable "cluster_id" {
+  type        = string
+  description = "The ID of the Consul cluster that is managing the clients"
+}
+
+variable "consul_version" {
+  type        = string
+  description = "The Consul version of the HCP servers"
+}
+
+/*
+ *
+ * Optional Variables
+ *
+ */
+
+variable "chart_version" {
+  type        = string
+  description = "The Consul Helm chart version to use"
+  default     = "0.40.0"
+}


### PR DESCRIPTION
# Description

JIRA: [HCS-3174](https://hashicorp.atlassian.net/browse/HCS-3174)

This PR adds an AKS client module as well as an example that demonstrates how
one could create an HCP Consul cluster and an AKS cluster in Azure and peer
them. It is mostly the same as the existing PR here which I tested and ensured
was functional:

https://github.com/hashicorp/terraform-azurerm-hcp-consul/pull/2

I chose to open a separate PR because I didn't want to stomp on that branch.

I've made the following changes so that this example is consistent with the
existing examples in this repo and the `terraform-aws-hcp-consul` repo:

- Authentication strategy
    - Removed required terraform vars
    - Depend on environment variables for HCP service principle and `az login`
      for Azure subscription/tenant
- Folder structure
    - Moved `hcp-aks-client` to proper `modules` directory
- File naming convention
    - Renamed `aks-client` to `hcp-aks-client`
    - Combined/renamed `aks.tf` and `azure-setup.tf` to `main.tf`
- Documentation
    - Added README.md to the `hcp-aks-client` module and `hcp-aks-demo` example

**Note:** This example is not entirely complete yet. We still need to implement
the Hashicups demo application within the AKS cluster and then add the
quickstart template for the HCP portal to consume.
