### PR TITLE
Remove `local.vnet_cidrs` from existing aks template

### DIFF
--- a/hcp-ui-templates/aks-existing-vnet/main.tf
+++ b/hcp-ui-templates/aks-existing-vnet/main.tf
@@ -5,7 +5,6 @@ locals {
   subscription_id = "{{ .SubscriptionID }}"
   vnet_rg_name    = "{{ .VnetRgName }}"
   vnet_id         = "/subscriptions/{{ .SubscriptionID }}/resourceGroups/{{ .VnetRgName }}/providers/Microsoft.Network/virtualNetworks/{{ .VnetName }}"
-  vnet_cidrs      = ["{{ .VnetCidr }}"]
   subnet1_id      = "/subscriptions/{{ .SubscriptionID }}/resourceGroups/{{ .VnetRgName }}/providers/Microsoft.Network/virtualNetworks/{{ .VnetName }}/subnets/{{ .Subnet1Name }}"
   subnet2_id      = "/subscriptions/{{ .SubscriptionID }}/resourceGroups/{{ .VnetRgName }}/providers/Microsoft.Network/virtualNetworks/{{ .VnetName }}/subnets/{{ .Subnet2Name }}"
   vnet_subnets = {

--- a/scripts/snips/aks_locals_existing_vnet.snip
+++ b/scripts/snips/aks_locals_existing_vnet.snip
@@ -1,7 +1,6 @@
   subscription_id = "{{ .SubscriptionID }}"
   vnet_rg_name    = "{{ .VnetRgName }}"
   vnet_id         = "/subscriptions/{{ .SubscriptionID }}/resourceGroups/{{ .VnetRgName }}/providers/Microsoft.Network/virtualNetworks/{{ .VnetName }}"
-  vnet_cidrs      = ["{{ .VnetCidr }}"]
   subnet1_id      = "/subscriptions/{{ .SubscriptionID }}/resourceGroups/{{ .VnetRgName }}/providers/Microsoft.Network/virtualNetworks/{{ .VnetName }}/subnets/{{ .Subnet1Name }}"
   subnet2_id      = "/subscriptions/{{ .SubscriptionID }}/resourceGroups/{{ .VnetRgName }}/providers/Microsoft.Network/virtualNetworks/{{ .VnetName }}/subnets/{{ .Subnet2Name }}"
   vnet_subnets    = {


### PR DESCRIPTION
This removes `.VnetCidr` from the template:

```
- vnet_cidrs      = ["{{ .VnetCidr }}"]
```