### PR TITLE
Adding in node id so we can differentiate attached nodes

### DIFF
--- a/modules/hcp-vm-client/main.tf
+++ b/modules/hcp-vm-client/main.tf
@@ -89,7 +89,7 @@ resource "azurerm_linux_virtual_machine" "vm" {
 
   user_data = base64encode(templatefile("${path.module}/templates/user_data.sh", {
     setup = base64gzip(templatefile("${path.module}/templates/setup.sh", {
-      subnet_id        = var.subnet_id,
+      node_id          = var.node_id,
       consul_config    = var.client_config_file,
       consul_ca        = var.client_ca_file,
       consul_acl_token = var.root_token,

--- a/modules/hcp-vm-client/main.tf
+++ b/modules/hcp-vm-client/main.tf
@@ -89,6 +89,7 @@ resource "azurerm_linux_virtual_machine" "vm" {
 
   user_data = base64encode(templatefile("${path.module}/templates/user_data.sh", {
     setup = base64gzip(templatefile("${path.module}/templates/setup.sh", {
+      subnet_id        = var.subnet_id,
       consul_config    = var.client_config_file,
       consul_ca        = var.client_ca_file,
       consul_acl_token = var.root_token,

--- a/modules/hcp-vm-client/templates/setup.sh
+++ b/modules/hcp-vm-client/templates/setup.sh
@@ -41,7 +41,7 @@ setup_consul() {
     jq '.ca_file = "/etc/consul.d/ca.pem"' client.temp.0 > client.temp.1
     jq --arg token "${consul_acl_token}" '.acl += {"tokens":{"agent":"\($token)"}}' client.temp.1 > client.temp.2
     jq '.ports = {"grpc":8502}' client.temp.2 > client.temp.3
-    jq --arg subnet_id "${subnet_id}" '.acl += {"node_meta":{"subnet_id":"\($subnet_id)"}}' client.temp.3 > client.temp.4
+    jq --arg subnet_id "${subnet_id}" '.node_meta += {"subnet_id":"\($subnet_id)"}' client.temp.3 > client.temp.4
     jq '.bind_addr = "{{ GetPrivateIP }}"' client.temp.4 > /etc/consul.d/client.json
 }
 

--- a/modules/hcp-vm-client/templates/setup.sh
+++ b/modules/hcp-vm-client/templates/setup.sh
@@ -41,7 +41,7 @@ setup_consul() {
     jq '.ca_file = "/etc/consul.d/ca.pem"' client.temp.0 > client.temp.1
     jq --arg token "${consul_acl_token}" '.acl += {"tokens":{"agent":"\($token)"}}' client.temp.1 > client.temp.2
     jq '.ports = {"grpc":8502}' client.temp.2 > client.temp.3
-    jq --arg subnet_id "${subnet_id}" '.node_meta += {"subnet_id":"\($subnet_id)"}' client.temp.3 > client.temp.4
+    jq --arg node_id "${node_id}" '.node_meta += {"node_id":"\($node_id)"}' client.temp.3 > client.temp.4
     jq '.bind_addr = "{{ GetPrivateIP }}"' client.temp.4 > /etc/consul.d/client.json
 }
 

--- a/modules/hcp-vm-client/templates/setup.sh
+++ b/modules/hcp-vm-client/templates/setup.sh
@@ -41,7 +41,8 @@ setup_consul() {
     jq '.ca_file = "/etc/consul.d/ca.pem"' client.temp.0 > client.temp.1
     jq --arg token "${consul_acl_token}" '.acl += {"tokens":{"agent":"\($token)"}}' client.temp.1 > client.temp.2
     jq '.ports = {"grpc":8502}' client.temp.2 > client.temp.3
-    jq '.bind_addr = "{{ GetPrivateIP }}"' client.temp.3 > /etc/consul.d/client.json
+    jq --arg subnet_id "${subnet_id}" '.acl += {"node_meta":{"subnet_id":"\($subnet_id)"}}' client.temp.3 > client.temp.4
+    jq '.bind_addr = "{{ GetPrivateIP }}"' client.temp.4 > /etc/consul.d/client.json
 }
 
 setup_nginx() {

--- a/modules/hcp-vm-client/variables.tf
+++ b/modules/hcp-vm-client/variables.tf
@@ -70,5 +70,5 @@ variable "vm_admin_password" {
 variable "node_id" {
   description = "A value to uniquely identify a node. This value will be added under the node_meta field for the consul agent as node_id"
   type        = string
-  default     = "identifier"
+  default     = ""
 }

--- a/modules/hcp-vm-client/variables.tf
+++ b/modules/hcp-vm-client/variables.tf
@@ -66,3 +66,9 @@ variable "vm_admin_password" {
   type        = string
   description = "admin password for the Azure VM"
 }
+
+variable "node_id" {
+  description = "A value to uniquely identify a node. This value will be added under the node_meta field for the consul agent as node_id"
+  type        = string
+  default     = "identifier"
+}


### PR DESCRIPTION
If we run this example and destroy and run it again a call to nodes list doesn't allow us to differentiate the nodes. Adding subnet id as node meta allows us to identify the node. Using subnet_id also avoids having to add another input variable to this example.