### PR TITLE
Bump from 0.2.5 to 0.2.7

### DIFF
--- a/examples/hcp-aks-demo/main.tf
+++ b/examples/hcp-aks-demo/main.tf
@@ -46,7 +46,7 @@ resource "hcp_hvn" "hvn" {
 # Peer the HVN to the vnet.
 module "hcp_peering" {
   source  = "hashicorp/hcp-consul/azurerm"
-  version = "~> 0.2.5"
+  version = "~> 0.2.7"
 
   hvn    = hcp_hvn.hvn
   prefix = var.cluster_id
@@ -114,7 +114,7 @@ resource "azurerm_kubernetes_cluster" "k8" {
 # Create a Kubernetes client that deploys Consul and its secrets.
 module "aks_consul_client" {
   source  = "hashicorp/hcp-consul/azurerm//modules/hcp-aks-client"
-  version = "~> 0.2.5"
+  version = "~> 0.2.7"
 
   cluster_id       = hcp_consul_cluster.main.cluster_id
   consul_hosts     = jsondecode(base64decode(hcp_consul_cluster.main.consul_config_file))["retry_join"]
@@ -135,7 +135,7 @@ module "aks_consul_client" {
 # Deploy Hashicups.
 module "demo_app" {
   source  = "hashicorp/hcp-consul/azurerm//modules/k8s-demo-app"
-  version = "~> 0.2.5"
+  version = "~> 0.2.7"
 
   depends_on = [module.aks_consul_client]
 }

--- a/examples/hcp-vm-demo/main.tf
+++ b/examples/hcp-vm-demo/main.tf
@@ -48,7 +48,7 @@ resource "hcp_hvn" "hvn" {
 
 module "hcp_peering" {
   source  = "hashicorp/hcp-consul/azurerm"
-  version = "~> 0.2.5"
+  version = "~> 0.2.7"
 
   # Required
   tenant_id       = data.azurerm_subscription.current.tenant_id
@@ -76,7 +76,7 @@ resource "hcp_consul_cluster_root_token" "token" {
 
 module "vm_client" {
   source  = "hashicorp/hcp-consul/azurerm//modules/hcp-vm-client"
-  version = "~> 0.2.5"
+  version = "~> 0.2.7"
 
   resource_group = azurerm_resource_group.rg.name
   location       = azurerm_resource_group.rg.location

--- a/hcp-ui-templates/aks-existing-vnet/main.tf
+++ b/hcp-ui-templates/aks-existing-vnet/main.tf
@@ -120,7 +120,7 @@ resource "hcp_hvn" "hvn" {
 # Peer the HVN to the vnet.
 module "hcp_peering" {
   source  = "hashicorp/hcp-consul/azurerm"
-  version = "~> 0.2.5"
+  version = "~> 0.2.7"
 
   hvn    = hcp_hvn.hvn
   prefix = local.cluster_id
@@ -187,7 +187,7 @@ resource "azurerm_kubernetes_cluster" "k8" {
 # Create a Kubernetes client that deploys Consul and its secrets.
 module "aks_consul_client" {
   source  = "hashicorp/hcp-consul/azurerm//modules/hcp-aks-client"
-  version = "~> 0.2.5"
+  version = "~> 0.2.7"
 
   cluster_id       = hcp_consul_cluster.main.cluster_id
   consul_hosts     = jsondecode(base64decode(hcp_consul_cluster.main.consul_config_file))["retry_join"]
@@ -208,7 +208,7 @@ module "aks_consul_client" {
 # Deploy Hashicups.
 module "demo_app" {
   source  = "hashicorp/hcp-consul/azurerm//modules/k8s-demo-app"
-  version = "~> 0.2.5"
+  version = "~> 0.2.7"
 
   depends_on = [module.aks_consul_client]
 }

--- a/hcp-ui-templates/aks/main.tf
+++ b/hcp-ui-templates/aks/main.tf
@@ -135,7 +135,7 @@ resource "hcp_hvn" "hvn" {
 # Peer the HVN to the vnet.
 module "hcp_peering" {
   source  = "hashicorp/hcp-consul/azurerm"
-  version = "~> 0.2.5"
+  version = "~> 0.2.7"
 
   hvn    = hcp_hvn.hvn
   prefix = local.cluster_id
@@ -203,7 +203,7 @@ resource "azurerm_kubernetes_cluster" "k8" {
 # Create a Kubernetes client that deploys Consul and its secrets.
 module "aks_consul_client" {
   source  = "hashicorp/hcp-consul/azurerm//modules/hcp-aks-client"
-  version = "~> 0.2.5"
+  version = "~> 0.2.7"
 
   cluster_id       = hcp_consul_cluster.main.cluster_id
   consul_hosts     = jsondecode(base64decode(hcp_consul_cluster.main.consul_config_file))["retry_join"]
@@ -224,7 +224,7 @@ module "aks_consul_client" {
 # Deploy Hashicups.
 module "demo_app" {
   source  = "hashicorp/hcp-consul/azurerm//modules/k8s-demo-app"
-  version = "~> 0.2.5"
+  version = "~> 0.2.7"
 
   depends_on = [module.aks_consul_client]
 }

--- a/hcp-ui-templates/vm-existing-vnet/main.tf
+++ b/hcp-ui-templates/vm-existing-vnet/main.tf
@@ -75,7 +75,7 @@ resource "hcp_hvn" "hvn" {
 
 module "hcp_peering" {
   source  = "hashicorp/hcp-consul/azurerm"
-  version = "~> 0.2.5"
+  version = "~> 0.2.7"
 
   # Required
   tenant_id       = data.azurerm_subscription.current.tenant_id
@@ -103,7 +103,7 @@ resource "hcp_consul_cluster_root_token" "token" {
 
 module "vm_client" {
   source  = "hashicorp/hcp-consul/azurerm//modules/hcp-vm-client"
-  version = "~> 0.2.5"
+  version = "~> 0.2.7"
 
   resource_group = data.azurerm_resource_group.rg.name
   location       = data.azurerm_resource_group.rg.location

--- a/hcp-ui-templates/vm/main.tf
+++ b/hcp-ui-templates/vm/main.tf
@@ -99,7 +99,7 @@ resource "hcp_hvn" "hvn" {
 
 module "hcp_peering" {
   source  = "hashicorp/hcp-consul/azurerm"
-  version = "~> 0.2.5"
+  version = "~> 0.2.7"
 
   # Required
   tenant_id       = data.azurerm_subscription.current.tenant_id
@@ -127,7 +127,7 @@ resource "hcp_consul_cluster_root_token" "token" {
 
 module "vm_client" {
   source  = "hashicorp/hcp-consul/azurerm//modules/hcp-vm-client"
-  version = "~> 0.2.5"
+  version = "~> 0.2.7"
 
   resource_group = azurerm_resource_group.rg.name
   location       = azurerm_resource_group.rg.location

--- a/scripts/module_version.sh
+++ b/scripts/module_version.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
-old="0\.2\.4"
-new=0.2.5
+old="0\.2\.5"
+new=0.2.7
 
 for platform in vm aks; do
   file=examples/hcp-$platform-demo/main.tf

--- a/test/hcp/testdata/vm-existing-vnet.golden
+++ b/test/hcp/testdata/vm-existing-vnet.golden
@@ -75,7 +75,7 @@ resource "hcp_hvn" "hvn" {
 
 module "hcp_peering" {
   source  = "hashicorp/hcp-consul/azurerm"
-  version = "~> 0.2.5"
+  version = "~> 0.2.7"
 
   # Required
   tenant_id       = data.azurerm_subscription.current.tenant_id
@@ -103,7 +103,7 @@ resource "hcp_consul_cluster_root_token" "token" {
 
 module "vm_client" {
   source  = "hashicorp/hcp-consul/azurerm//modules/hcp-vm-client"
-  version = "~> 0.2.5"
+  version = "~> 0.2.7"
 
   resource_group = data.azurerm_resource_group.rg.name
   location       = data.azurerm_resource_group.rg.location

--- a/test/hcp/testdata/vm.golden
+++ b/test/hcp/testdata/vm.golden
@@ -99,7 +99,7 @@ resource "hcp_hvn" "hvn" {
 
 module "hcp_peering" {
   source  = "hashicorp/hcp-consul/azurerm"
-  version = "~> 0.2.5"
+  version = "~> 0.2.7"
 
   # Required
   tenant_id       = data.azurerm_subscription.current.tenant_id
@@ -127,7 +127,7 @@ resource "hcp_consul_cluster_root_token" "token" {
 
 module "vm_client" {
   source  = "hashicorp/hcp-consul/azurerm//modules/hcp-vm-client"
-  version = "~> 0.2.5"
+  version = "~> 0.2.7"
 
   resource_group = azurerm_resource_group.rg.name
   location       = azurerm_resource_group.rg.location


### PR DESCRIPTION
It appears that [0.2.6 was released](https://registry.terraform.io/modules/hashicorp/hcp-consul/azurerm/latest?tab=inputs) but none of the versions were bumped in the files to 0.2.6

Bumping to 0.2.7 for node_id changes.