### PR TITLE
Increase HashiCups restarts

### DIFF
--- a/examples/hcp-aks-demo/main.tf
+++ b/examples/hcp-aks-demo/main.tf
@@ -46,7 +46,7 @@ resource "hcp_hvn" "hvn" {
 # Peer the HVN to the vnet.
 module "hcp_peering" {
   source  = "hashicorp/hcp-consul/azurerm"
-  version = "~> 0.2.7"
+  version = "~> 0.2.8"
 
   hvn    = hcp_hvn.hvn
   prefix = var.cluster_id
@@ -114,7 +114,7 @@ resource "azurerm_kubernetes_cluster" "k8" {
 # Create a Kubernetes client that deploys Consul and its secrets.
 module "aks_consul_client" {
   source  = "hashicorp/hcp-consul/azurerm//modules/hcp-aks-client"
-  version = "~> 0.2.7"
+  version = "~> 0.2.8"
 
   cluster_id       = hcp_consul_cluster.main.cluster_id
   consul_hosts     = jsondecode(base64decode(hcp_consul_cluster.main.consul_config_file))["retry_join"]
@@ -135,7 +135,7 @@ module "aks_consul_client" {
 # Deploy Hashicups.
 module "demo_app" {
   source  = "hashicorp/hcp-consul/azurerm//modules/k8s-demo-app"
-  version = "~> 0.2.7"
+  version = "~> 0.2.8"
 
   depends_on = [module.aks_consul_client]
 }

--- a/examples/hcp-vm-demo/main.tf
+++ b/examples/hcp-vm-demo/main.tf
@@ -48,7 +48,7 @@ resource "hcp_hvn" "hvn" {
 
 module "hcp_peering" {
   source  = "hashicorp/hcp-consul/azurerm"
-  version = "~> 0.2.7"
+  version = "~> 0.2.8"
 
   # Required
   tenant_id       = data.azurerm_subscription.current.tenant_id
@@ -76,7 +76,7 @@ resource "hcp_consul_cluster_root_token" "token" {
 
 module "vm_client" {
   source  = "hashicorp/hcp-consul/azurerm//modules/hcp-vm-client"
-  version = "~> 0.2.7"
+  version = "~> 0.2.8"
 
   resource_group = azurerm_resource_group.rg.name
   location       = azurerm_resource_group.rg.location

--- a/hcp-ui-templates/aks-existing-vnet/main.tf
+++ b/hcp-ui-templates/aks-existing-vnet/main.tf
@@ -120,7 +120,7 @@ resource "hcp_hvn" "hvn" {
 # Peer the HVN to the vnet.
 module "hcp_peering" {
   source  = "hashicorp/hcp-consul/azurerm"
-  version = "~> 0.2.7"
+  version = "~> 0.2.8"
 
   hvn    = hcp_hvn.hvn
   prefix = local.cluster_id
@@ -187,7 +187,7 @@ resource "azurerm_kubernetes_cluster" "k8" {
 # Create a Kubernetes client that deploys Consul and its secrets.
 module "aks_consul_client" {
   source  = "hashicorp/hcp-consul/azurerm//modules/hcp-aks-client"
-  version = "~> 0.2.7"
+  version = "~> 0.2.8"
 
   cluster_id       = hcp_consul_cluster.main.cluster_id
   consul_hosts     = jsondecode(base64decode(hcp_consul_cluster.main.consul_config_file))["retry_join"]
@@ -208,7 +208,7 @@ module "aks_consul_client" {
 # Deploy Hashicups.
 module "demo_app" {
   source  = "hashicorp/hcp-consul/azurerm//modules/k8s-demo-app"
-  version = "~> 0.2.7"
+  version = "~> 0.2.8"
 
   depends_on = [module.aks_consul_client]
 }

--- a/hcp-ui-templates/aks/main.tf
+++ b/hcp-ui-templates/aks/main.tf
@@ -135,7 +135,7 @@ resource "hcp_hvn" "hvn" {
 # Peer the HVN to the vnet.
 module "hcp_peering" {
   source  = "hashicorp/hcp-consul/azurerm"
-  version = "~> 0.2.7"
+  version = "~> 0.2.8"
 
   hvn    = hcp_hvn.hvn
   prefix = local.cluster_id
@@ -203,7 +203,7 @@ resource "azurerm_kubernetes_cluster" "k8" {
 # Create a Kubernetes client that deploys Consul and its secrets.
 module "aks_consul_client" {
   source  = "hashicorp/hcp-consul/azurerm//modules/hcp-aks-client"
-  version = "~> 0.2.7"
+  version = "~> 0.2.8"
 
   cluster_id       = hcp_consul_cluster.main.cluster_id
   consul_hosts     = jsondecode(base64decode(hcp_consul_cluster.main.consul_config_file))["retry_join"]
@@ -224,7 +224,7 @@ module "aks_consul_client" {
 # Deploy Hashicups.
 module "demo_app" {
   source  = "hashicorp/hcp-consul/azurerm//modules/k8s-demo-app"
-  version = "~> 0.2.7"
+  version = "~> 0.2.8"
 
   depends_on = [module.aks_consul_client]
 }

--- a/hcp-ui-templates/vm-existing-vnet/main.tf
+++ b/hcp-ui-templates/vm-existing-vnet/main.tf
@@ -75,7 +75,7 @@ resource "hcp_hvn" "hvn" {
 
 module "hcp_peering" {
   source  = "hashicorp/hcp-consul/azurerm"
-  version = "~> 0.2.7"
+  version = "~> 0.2.8"
 
   # Required
   tenant_id       = data.azurerm_subscription.current.tenant_id
@@ -103,7 +103,7 @@ resource "hcp_consul_cluster_root_token" "token" {
 
 module "vm_client" {
   source  = "hashicorp/hcp-consul/azurerm//modules/hcp-vm-client"
-  version = "~> 0.2.7"
+  version = "~> 0.2.8"
 
   resource_group = data.azurerm_resource_group.rg.name
   location       = data.azurerm_resource_group.rg.location

--- a/hcp-ui-templates/vm/main.tf
+++ b/hcp-ui-templates/vm/main.tf
@@ -99,7 +99,7 @@ resource "hcp_hvn" "hvn" {
 
 module "hcp_peering" {
   source  = "hashicorp/hcp-consul/azurerm"
-  version = "~> 0.2.7"
+  version = "~> 0.2.8"
 
   # Required
   tenant_id       = data.azurerm_subscription.current.tenant_id
@@ -127,7 +127,7 @@ resource "hcp_consul_cluster_root_token" "token" {
 
 module "vm_client" {
   source  = "hashicorp/hcp-consul/azurerm//modules/hcp-vm-client"
-  version = "~> 0.2.7"
+  version = "~> 0.2.8"
 
   resource_group = azurerm_resource_group.rg.name
   location       = azurerm_resource_group.rg.location

--- a/modules/hcp-vm-client/templates/hashicups.nomad
+++ b/modules/hcp-vm-client/templates/hashicups.nomad
@@ -1,26 +1,26 @@
 variable "frontend_port" {
-  type        = number
-  default     = 3000
+  type    = number
+  default = 3000
 }
 
 variable "public_api_port" {
-  type        = number
-  default     = 7070
+  type    = number
+  default = 7070
 }
 
 variable "payment_api_port" {
-  type        = number
-  default     = 8080
+  type    = number
+  default = 8080
 }
 
 variable "product_api_port" {
-  type        = number
-  default     = 9090
+  type    = number
+  default = 9090
 }
 
 variable "product_db_port" {
-  type        = number
-  default     = 5432
+  type    = number
+  default = 5432
 }
 
 job "hashicups" {
@@ -51,6 +51,13 @@ job "hashicups" {
       env {
         NEXT_PUBLIC_PUBLIC_API_URL = "/"
       }
+    }
+
+    restart {
+      interval = "30m"
+      attempts = 15
+      delay    = "30s"
+      mode     = "fail"
     }
   }
 
@@ -92,10 +99,17 @@ job "hashicups" {
       }
 
       env {
-        BIND_ADDRESS = ":${var.public_api_port}"
+        BIND_ADDRESS    = ":${var.public_api_port}"
         PRODUCT_API_URI = "http://localhost:${var.product_api_port}"
         PAYMENT_API_URI = "http://localhost:${var.payment_api_port}"
       }
+    }
+
+    restart {
+      interval = "30m"
+      attempts = 15
+      delay    = "30s"
+      mode     = "fail"
     }
   }
 
@@ -124,6 +138,13 @@ job "hashicups" {
         image = "hashicorpdemoapp/payments:v0.0.16"
         ports = ["http"]
       }
+    }
+
+    restart {
+      interval = "30m"
+      attempts = 15
+      delay    = "30s"
+      mode     = "fail"
     }
   }
 
@@ -177,6 +198,13 @@ job "hashicups" {
         BIND_ADDRESS  = "localhost:${var.product_api_port}"
       }
     }
+
+    restart {
+      interval = "30m"
+      attempts = 15
+      delay    = "30s"
+      mode     = "fail"
+    }
   }
 
   group "product-db" {
@@ -210,6 +238,13 @@ job "hashicups" {
         POSTGRES_USER     = "postgres"
         POSTGRES_PASSWORD = "password"
       }
+    }
+
+    restart {
+      interval = "30m"
+      attempts = 15
+      delay    = "30s"
+      mode     = "fail"
     }
   }
 }

--- a/scripts/module_version.sh
+++ b/scripts/module_version.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
-old="0\.2\.5"
-new=0.2.7
+old="0\.2\.7"
+new=0.2.8
 
 for platform in vm aks; do
   file=examples/hcp-$platform-demo/main.tf

--- a/test/hcp/testdata/vm-existing-vnet.golden
+++ b/test/hcp/testdata/vm-existing-vnet.golden
@@ -75,7 +75,7 @@ resource "hcp_hvn" "hvn" {
 
 module "hcp_peering" {
   source  = "hashicorp/hcp-consul/azurerm"
-  version = "~> 0.2.7"
+  version = "~> 0.2.8"
 
   # Required
   tenant_id       = data.azurerm_subscription.current.tenant_id
@@ -103,7 +103,7 @@ resource "hcp_consul_cluster_root_token" "token" {
 
 module "vm_client" {
   source  = "hashicorp/hcp-consul/azurerm//modules/hcp-vm-client"
-  version = "~> 0.2.7"
+  version = "~> 0.2.8"
 
   resource_group = data.azurerm_resource_group.rg.name
   location       = data.azurerm_resource_group.rg.location

--- a/test/hcp/testdata/vm.golden
+++ b/test/hcp/testdata/vm.golden
@@ -99,7 +99,7 @@ resource "hcp_hvn" "hvn" {
 
 module "hcp_peering" {
   source  = "hashicorp/hcp-consul/azurerm"
-  version = "~> 0.2.7"
+  version = "~> 0.2.8"
 
   # Required
   tenant_id       = data.azurerm_subscription.current.tenant_id
@@ -127,7 +127,7 @@ resource "hcp_consul_cluster_root_token" "token" {
 
 module "vm_client" {
   source  = "hashicorp/hcp-consul/azurerm//modules/hcp-vm-client"
-  version = "~> 0.2.7"
+  version = "~> 0.2.8"
 
   resource_group = azurerm_resource_group.rg.name
   location       = azurerm_resource_group.rg.location


### PR DESCRIPTION
We see occasional HashiCup allocation failures that can be resolved with more restarts. This adds restarts to all Nomad groups. We're using the Group level rather than Task level so the restarts also apply to the Consul Connect sidecar. AWS TF equivalent change: https://github.com/hashicorp/terraform-aws-hcp-consul/commit/2981c194ac9a03cbd175b93baefb7b698795a3a6