### PR TITLE
Remove license/copyright headers from ui-template and golden files

### DIFF
--- a/hcp-ui-templates/aks-existing-vnet/main.tf
+++ b/hcp-ui-templates/aks-existing-vnet/main.tf
@@ -1,6 +1,3 @@
-# Copyright (c) HashiCorp, Inc.
-# SPDX-License-Identifier: MPL-2.0
-
 locals {
   hvn_region      = "{{ .HVNRegion }}"
   hvn_id          = "{{ .ClusterID }}-hvn"
@@ -15,6 +12,7 @@ locals {
     "subnet2" = local.subnet2_id,
   }
 }
+
 
 terraform {
   required_providers {
@@ -94,6 +92,7 @@ provider "consul" {
   datacenter = hcp_consul_cluster.main.datacenter
   token      = hcp_consul_cluster_root_token.token.secret_id
 }
+
 data "azurerm_subscription" "current" {}
 
 data "azurerm_resource_group" "rg" {
@@ -134,7 +133,7 @@ resource "hcp_hvn" "hvn" {
 #   subscription_id      = data.azurerm_subscription.current.subscription_id
 #   tenant_id            = data.azurerm_subscription.current.tenant_id
 #
-#   subnet_ids = [local.subnet1_id, local.subnet2_id]
+#   subnet_ids = [local.subnet1_id,local.subnet2_id]
 #   vnet_id    = local.vnet_id
 #   vnet_rg    = data.azurerm_resource_group.rg.name
 # }
@@ -233,6 +232,7 @@ resource "azurerm_network_security_rule" "ingress" {
 
   depends_on = [module.demo_app]
 }
+
 output "consul_root_token" {
   value     = hcp_consul_cluster_root_token.token.secret_id
   sensitive = true

--- a/hcp-ui-templates/aks/main.tf
+++ b/hcp-ui-templates/aks/main.tf
@@ -1,6 +1,3 @@
-# Copyright (c) HashiCorp, Inc.
-# SPDX-License-Identifier: MPL-2.0
-
 locals {
   hvn_region     = "{{ .HVNRegion }}"
   hvn_id         = "{{ .ClusterID }}-hvn"
@@ -12,6 +9,7 @@ locals {
     "subnet2" = "10.0.2.0/24",
   }
 }
+
 
 terraform {
   required_providers {
@@ -90,6 +88,7 @@ provider "consul" {
   datacenter = hcp_consul_cluster.main.datacenter
   token      = hcp_consul_cluster_root_token.token.secret_id
 }
+
 data "azurerm_subscription" "current" {}
 
 resource "azurerm_resource_group" "rg" {
@@ -249,6 +248,7 @@ resource "azurerm_network_security_rule" "ingress" {
 
   depends_on = [module.demo_app]
 }
+
 output "consul_root_token" {
   value     = hcp_consul_cluster_root_token.token.secret_id
   sensitive = true

--- a/hcp-ui-templates/vm-existing-vnet/main.tf
+++ b/hcp-ui-templates/vm-existing-vnet/main.tf
@@ -1,6 +1,3 @@
-# Copyright (c) HashiCorp, Inc.
-# SPDX-License-Identifier: MPL-2.0
-
 locals {
   hvn_region      = "{{ .HVNRegion }}"
   hvn_id          = "{{ .ClusterID }}-hvn"
@@ -10,6 +7,7 @@ locals {
   vnet_id         = "/subscriptions/{{ .SubscriptionID }}/resourceGroups/{{ .VnetRgName }}/providers/Microsoft.Network/virtualNetworks/{{ .VnetName }}"
   subnet1_id      = "/subscriptions/{{ .SubscriptionID }}/resourceGroups/{{ .VnetRgName }}/providers/Microsoft.Network/virtualNetworks/{{ .VnetName }}/subnets/{{ .SubnetName }}"
 }
+
 
 
 terraform {
@@ -52,6 +50,7 @@ provider "consul" {
   datacenter = hcp_consul_cluster.main.datacenter
   token      = hcp_consul_cluster_root_token.token.secret_id
 }
+
 
 data "azurerm_subscription" "current" {}
 
@@ -123,6 +122,7 @@ module "vm_client" {
   root_token         = hcp_consul_cluster_root_token.token.secret_id
   consul_version     = hcp_consul_cluster.main.consul_version
 }
+
 
 output "consul_root_token" {
   value     = hcp_consul_cluster_root_token.token.secret_id

--- a/hcp-ui-templates/vm/main.tf
+++ b/hcp-ui-templates/vm/main.tf
@@ -1,6 +1,3 @@
-# Copyright (c) HashiCorp, Inc.
-# SPDX-License-Identifier: MPL-2.0
-
 locals {
   hvn_region     = "{{ .HVNRegion }}"
   hvn_id         = "{{ .ClusterID }}-hvn"
@@ -11,6 +8,7 @@ locals {
     "subnet1" = "10.0.1.0/24",
   }
 }
+
 
 
 terraform {
@@ -52,6 +50,7 @@ provider "consul" {
   datacenter = hcp_consul_cluster.main.datacenter
   token      = hcp_consul_cluster_root_token.token.secret_id
 }
+
 
 data "azurerm_subscription" "current" {}
 
@@ -147,6 +146,7 @@ module "vm_client" {
   root_token         = hcp_consul_cluster_root_token.token.secret_id
   consul_version     = hcp_consul_cluster.main.consul_version
 }
+
 
 output "consul_root_token" {
   value     = hcp_consul_cluster_root_token.token.secret_id

--- a/scripts/generate_ui_templates.sh
+++ b/scripts/generate_ui_templates.sh
@@ -8,7 +8,9 @@ generate_base_terraform () {
     | sed -e '/provider_meta/,+2d' \
     | sed -e 's/var/local/g' \
     | sed -e 's/local\.tier/"development"/g' \
-    | sed -e 's/local\.hvn_cidr_block/"172.25.32.0\/20"/g'
+    | sed -e 's/local\.hvn_cidr_block/"172.25.32.0\/20"/g' \
+    | sed -e '/Copyright/d' \
+    | sed -e '/License/d'
 }
 
 generate_base_existing_vnet_terraform () {

--- a/test/hcp/testdata/vm-existing-vnet.golden
+++ b/test/hcp/testdata/vm-existing-vnet.golden
@@ -1,6 +1,3 @@
-# Copyright (c) HashiCorp, Inc.
-# SPDX-License-Identifier: MPL-2.0
-
 locals {
   hvn_region      = "westus2"
   hvn_id          = "consul-quickstart-1634271483588-hvn"
@@ -10,6 +7,7 @@ locals {
   vnet_id         = "/subscriptions/26310ff2-35ad-4839-83fb-0f82f258779f/resourceGroups/myvnetresourcegroup/providers/Microsoft.Network/virtualNetworks/myvnetname"
   subnet1_id      = "/subscriptions/26310ff2-35ad-4839-83fb-0f82f258779f/resourceGroups/myvnetresourcegroup/providers/Microsoft.Network/virtualNetworks/myvnetname/subnets/mysubnetname"
 }
+
 
 
 terraform {
@@ -52,6 +50,7 @@ provider "consul" {
   datacenter = hcp_consul_cluster.main.datacenter
   token      = hcp_consul_cluster_root_token.token.secret_id
 }
+
 
 data "azurerm_subscription" "current" {}
 
@@ -123,6 +122,7 @@ module "vm_client" {
   root_token         = hcp_consul_cluster_root_token.token.secret_id
   consul_version     = hcp_consul_cluster.main.consul_version
 }
+
 
 output "consul_root_token" {
   value     = hcp_consul_cluster_root_token.token.secret_id

--- a/test/hcp/testdata/vm.golden
+++ b/test/hcp/testdata/vm.golden
@@ -1,6 +1,3 @@
-# Copyright (c) HashiCorp, Inc.
-# SPDX-License-Identifier: MPL-2.0
-
 locals {
   hvn_region     = "westus2"
   hvn_id         = "consul-quickstart-1634271483588-hvn"
@@ -11,6 +8,7 @@ locals {
     "subnet1" = "10.0.1.0/24",
   }
 }
+
 
 
 terraform {
@@ -52,6 +50,7 @@ provider "consul" {
   datacenter = hcp_consul_cluster.main.datacenter
   token      = hcp_consul_cluster_root_token.token.secret_id
 }
+
 
 data "azurerm_subscription" "current" {}
 
@@ -147,6 +146,7 @@ module "vm_client" {
   root_token         = hcp_consul_cluster_root_token.token.secret_id
   consul_version     = hcp_consul_cluster.main.consul_version
 }
+
 
 output "consul_root_token" {
   value     = hcp_consul_cluster_root_token.token.secret_id


### PR DESCRIPTION
This strips out license/copyright headers from autogenerated files. Otherwise we wind up with license/copyright headers getting spliced into ui templates + golden test files. The example below is from just running `make` without any other changes:

```diff
diff --git a/hcp-ui-templates/ec2-existing-vpc/main.tf b/hcp-ui-templates/ec2-existing-vpc/main.tf
index a6c87f9..4d287dd 100644
--- a/hcp-ui-templates/ec2-existing-vpc/main.tf
+++ b/hcp-ui-templates/ec2-existing-vpc/main.tf
@@ -1,6 +1,3 @@
-# Copyright (c) HashiCorp, Inc.
-# SPDX-License-Identifier: MPL-2.0
-
 locals {
   vpc_region            = "{{ .VPCRegion }}"
   hvn_region            = "{{ .HVNRegion }}"
@@ -13,6 +10,9 @@ locals {
   ssm                   = true
 }
 
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: MPL-2.0
+
 terraform {
   required_providers {
     aws = {
@@ -42,6 +42,9 @@ provider "nomad" {
   http_auth = "nomad:${hcp_consul_cluster_root_token.token.secret_id}"
 }
 
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: MPL-2.0
+
```