### PR TITLE
VM client enhancements

### DIFF
--- a/examples/hcp-aks-demo/main.tf
+++ b/examples/hcp-aks-demo/main.tf
@@ -54,7 +54,7 @@ resource "hcp_hvn" "hvn" {
 # Peer the HVN to the vnet.
 # module "hcp_peering" {
 #   source  = "hashicorp/hcp-consul/azurerm"
-#   version = "~> 0.4.0"
+#   version = "~> 0.5.0"
 #
 #   hvn    = hcp_hvn.hvn
 #   prefix = var.cluster_id
@@ -122,7 +122,7 @@ resource "azurerm_kubernetes_cluster" "k8" {
 # Create a Kubernetes client that deploys Consul and its secrets.
 module "aks_consul_client" {
   source  = "hashicorp/hcp-consul/azurerm//modules/hcp-aks-client"
-  version = "~> 0.4.0"
+  version = "~> 0.5.0"
 
   cluster_id = hcp_consul_cluster.main.cluster_id
 
@@ -142,7 +142,7 @@ module "aks_consul_client" {
 # Deploy Hashicups.
 module "demo_app" {
   source  = "hashicorp/hcp-consul/azurerm//modules/k8s-demo-app"
-  version = "~> 0.4.0"
+  version = "~> 0.5.0"
 
   depends_on = [module.aks_consul_client]
 }

--- a/examples/hcp-vm-demo/main.tf
+++ b/examples/hcp-vm-demo/main.tf
@@ -55,7 +55,7 @@ resource "hcp_hvn" "hvn" {
 
 module "hcp_peering" {
   source  = "hashicorp/hcp-consul/azurerm"
-  version = "~> 0.4.0"
+  version = "~> 0.5.0"
 
   # Required
   tenant_id       = data.azurerm_subscription.current.tenant_id
@@ -83,7 +83,7 @@ resource "hcp_consul_cluster_root_token" "token" {
 
 module "vm_client" {
   source  = "hashicorp/hcp-consul/azurerm//modules/hcp-vm-client"
-  version = "~> 0.4.0"
+  version = "~> 0.5.0"
 
   resource_group = azurerm_resource_group.rg.name
   location       = azurerm_resource_group.rg.location

--- a/hcp-ui-templates/aks-existing-vnet/main.tf
+++ b/hcp-ui-templates/aks-existing-vnet/main.tf
@@ -123,7 +123,7 @@ resource "hcp_hvn" "hvn" {
 # Peer the HVN to the vnet.
 # module "hcp_peering" {
 #   source  = "hashicorp/hcp-consul/azurerm"
-#   version = "~> 0.4.0"
+#   version = "~> 0.5.0"
 #
 #   hvn    = hcp_hvn.hvn
 #   prefix = local.cluster_id
@@ -190,7 +190,7 @@ resource "azurerm_kubernetes_cluster" "k8" {
 # Create a Kubernetes client that deploys Consul and its secrets.
 module "aks_consul_client" {
   source  = "hashicorp/hcp-consul/azurerm//modules/hcp-aks-client"
-  version = "~> 0.4.0"
+  version = "~> 0.5.0"
 
   cluster_id = hcp_consul_cluster.main.cluster_id
 
@@ -210,7 +210,7 @@ module "aks_consul_client" {
 # Deploy Hashicups.
 module "demo_app" {
   source  = "hashicorp/hcp-consul/azurerm//modules/k8s-demo-app"
-  version = "~> 0.4.0"
+  version = "~> 0.5.0"
 
   depends_on = [module.aks_consul_client]
 }

--- a/hcp-ui-templates/aks/main.tf
+++ b/hcp-ui-templates/aks/main.tf
@@ -142,7 +142,7 @@ resource "hcp_hvn" "hvn" {
 # Peer the HVN to the vnet.
 # module "hcp_peering" {
 #   source  = "hashicorp/hcp-consul/azurerm"
-#   version = "~> 0.4.0"
+#   version = "~> 0.5.0"
 #
 #   hvn    = hcp_hvn.hvn
 #   prefix = local.cluster_id
@@ -210,7 +210,7 @@ resource "azurerm_kubernetes_cluster" "k8" {
 # Create a Kubernetes client that deploys Consul and its secrets.
 module "aks_consul_client" {
   source  = "hashicorp/hcp-consul/azurerm//modules/hcp-aks-client"
-  version = "~> 0.4.0"
+  version = "~> 0.5.0"
 
   cluster_id = hcp_consul_cluster.main.cluster_id
 
@@ -230,7 +230,7 @@ module "aks_consul_client" {
 # Deploy Hashicups.
 module "demo_app" {
   source  = "hashicorp/hcp-consul/azurerm//modules/k8s-demo-app"
-  version = "~> 0.4.0"
+  version = "~> 0.5.0"
 
   depends_on = [module.aks_consul_client]
 }

--- a/hcp-ui-templates/vm-existing-vnet/main.tf
+++ b/hcp-ui-templates/vm-existing-vnet/main.tf
@@ -77,7 +77,7 @@ resource "hcp_hvn" "hvn" {
 
 module "hcp_peering" {
   source  = "hashicorp/hcp-consul/azurerm"
-  version = "~> 0.4.0"
+  version = "~> 0.5.0"
 
   # Required
   tenant_id       = data.azurerm_subscription.current.tenant_id
@@ -105,7 +105,7 @@ resource "hcp_consul_cluster_root_token" "token" {
 
 module "vm_client" {
   source  = "hashicorp/hcp-consul/azurerm//modules/hcp-vm-client"
-  version = "~> 0.4.0"
+  version = "~> 0.5.0"
 
   resource_group = data.azurerm_resource_group.rg.name
   location       = data.azurerm_resource_group.rg.location

--- a/hcp-ui-templates/vm/main.tf
+++ b/hcp-ui-templates/vm/main.tf
@@ -105,7 +105,7 @@ resource "hcp_hvn" "hvn" {
 
 module "hcp_peering" {
   source  = "hashicorp/hcp-consul/azurerm"
-  version = "~> 0.4.0"
+  version = "~> 0.5.0"
 
   # Required
   tenant_id       = data.azurerm_subscription.current.tenant_id
@@ -133,7 +133,7 @@ resource "hcp_consul_cluster_root_token" "token" {
 
 module "vm_client" {
   source  = "hashicorp/hcp-consul/azurerm//modules/hcp-vm-client"
-  version = "~> 0.4.0"
+  version = "~> 0.5.0"
 
   resource_group = azurerm_resource_group.rg.name
   location       = azurerm_resource_group.rg.location

--- a/modules/hcp-vm-client/templates/setup.sh
+++ b/modules/hcp-vm-client/templates/setup.sh
@@ -14,10 +14,14 @@ setup_deps () {
     add-apt-repository universe -y
     curl -fsSL https://apt.releases.hashicorp.com/gpg | sudo apt-key add -
     apt-add-repository "deb [arch=amd64] https://apt.releases.hashicorp.com $(lsb_release -cs) main"
+    # test repo for release candidate versions
+    apt-add-repository "deb [arch=amd64] https://apt.releases.hashicorp.com $(lsb_release -cs) test"
     curl -sL 'https://deb.dl.getenvoy.io/public/gpg.8115BA8E629CC074.key' | gpg --dearmor -o /usr/share/keyrings/getenvoy-keyring.gpg
     echo "deb [arch=amd64 signed-by=/usr/share/keyrings/getenvoy-keyring.gpg] https://deb.dl.getenvoy.io/public/deb/ubuntu $(lsb_release -cs) main" | tee /etc/apt/sources.list.d/getenvoy.list
     apt update -qy
-    version="${consul_version}"
+    # Note: apt is unable to find packages if '-rc*' is used. Hence trimming '-rc' from version which is present only in case
+    # of candidate release versions.
+    version=$(sed -r 's/-rc([0-9]*)//g'<<<${consul_version})
     consul_package="consul-enterprise="$${version:1}"*"
     apt install -qy apt-transport-https gnupg2 curl lsb-release nomad $${consul_package} getenvoy-envoy unzip jq apache2-utils nginx
     curl -fsSL https://get.docker.com -o get-docker.sh

--- a/scripts/module_version.sh
+++ b/scripts/module_version.sh
@@ -3,8 +3,8 @@
 # SPDX-License-Identifier: MPL-2.0
 
 
-old="0\.3\.2"
-new=0.4.0
+old="0\.4\.0"
+new=0.5.0
 
 for platform in vm aks; do
   file=examples/hcp-$platform-demo/main.tf

--- a/test/hcp/testdata/vm-existing-vnet.golden
+++ b/test/hcp/testdata/vm-existing-vnet.golden
@@ -77,7 +77,7 @@ resource "hcp_hvn" "hvn" {
 
 module "hcp_peering" {
   source  = "hashicorp/hcp-consul/azurerm"
-  version = "~> 0.4.0"
+  version = "~> 0.5.0"
 
   # Required
   tenant_id       = data.azurerm_subscription.current.tenant_id
@@ -105,7 +105,7 @@ resource "hcp_consul_cluster_root_token" "token" {
 
 module "vm_client" {
   source  = "hashicorp/hcp-consul/azurerm//modules/hcp-vm-client"
-  version = "~> 0.4.0"
+  version = "~> 0.5.0"
 
   resource_group = data.azurerm_resource_group.rg.name
   location       = data.azurerm_resource_group.rg.location

--- a/test/hcp/testdata/vm.golden
+++ b/test/hcp/testdata/vm.golden
@@ -105,7 +105,7 @@ resource "hcp_hvn" "hvn" {
 
 module "hcp_peering" {
   source  = "hashicorp/hcp-consul/azurerm"
-  version = "~> 0.4.0"
+  version = "~> 0.5.0"
 
   # Required
   tenant_id       = data.azurerm_subscription.current.tenant_id
@@ -133,7 +133,7 @@ resource "hcp_consul_cluster_root_token" "token" {
 
 module "vm_client" {
   source  = "hashicorp/hcp-consul/azurerm//modules/hcp-vm-client"
-  version = "~> 0.4.0"
+  version = "~> 0.5.0"
 
   resource_group = azurerm_resource_group.rg.name
   location       = azurerm_resource_group.rg.location


### PR DESCRIPTION
Allow installing release candidate versions of Consul on the VM client node.

Related JIRA: https://hashicorp.atlassian.net/browse/CC-6563

Tested it by referencing changes to local vm module within the hcp-vm-demo. 

Testing screenshots:

Successful terraform run
![image](https://github.com/hashicorp/terraform-azurerm-hcp-consul/assets/4574087/dd8f56eb-5708-4e2c-9d4d-d840e7097a8e)

1.17.0-rc1 version on Consul UI
<img width="770" alt="image" src="https://github.com/hashicorp/terraform-azurerm-hcp-consul/assets/4574087/93519a89-b397-49f9-89bf-957d9fa109fa">

Hashicups app
![image](https://github.com/hashicorp/terraform-azurerm-hcp-consul/assets/4574087/4d287154-f9b3-4aab-88d6-464a42597e20)


